### PR TITLE
Rewrite panic propagation

### DIFF
--- a/examples/12_subsystem_auto_restart.rs
+++ b/examples/12_subsystem_auto_restart.rs
@@ -1,0 +1,60 @@
+//! This example demonstrates how a subsystem could get implemented that auto-restarts
+//! every time a panic occurs.
+//!
+//! This isn't really a usecase related to this library, but seems to be used regularly,
+//! so I included it anyway.
+
+use anyhow::Result;
+use env_logger::{Builder, Env};
+use tokio::time::{sleep, Duration};
+use tokio_graceful_shutdown::{SubsystemHandle, Toplevel};
+
+async fn subsys1(subsys: SubsystemHandle) -> Result<()> {
+    // This subsystem panics every two seconds.
+    // It should get restarted constantly.
+
+    log::info!("Subsystem1 started.");
+    tokio::select! {
+        _ =subsys.on_shutdown_requested() => (),
+        _ = sleep(Duration::from_secs(2)) => {
+            panic!("Subsystem1 panicked!");
+        }
+    };
+    log::info!("Subsystem1 stopped.");
+
+    Ok(())
+}
+
+async fn subsys1_with_autorestart(subsys: SubsystemHandle) -> Result<()> {
+    loop {
+        let mut joinhandle = tokio::spawn(subsys1(subsys.clone()));
+        let joinhandle_ref = &mut joinhandle;
+        tokio::select! {
+            result = joinhandle_ref => {
+                    match result {
+                        Ok(result) => return result,
+                        Err(err) => {
+                            log::error!("Subsystem1 failed: {:?}", err);
+                            log::info!("Restarting subsystem1 ...");
+                        }
+                    }
+            },
+            _ = subsys.on_shutdown_requested() => {
+                return joinhandle.await?;
+            }
+        };
+    }
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<()> {
+    // Init logging
+    Builder::from_env(Env::default().default_filter_or("debug")).init();
+
+    // Create toplevel
+    Toplevel::new()
+        .start("Subsys1", subsys1_with_autorestart)
+        .catch_signals()
+        .wait_for_shutdown(Duration::from_millis(1000))
+        .await
+}

--- a/examples/12_subsystem_auto_restart.rs
+++ b/examples/12_subsystem_auto_restart.rs
@@ -15,7 +15,7 @@ async fn subsys1(subsys: SubsystemHandle) -> Result<()> {
 
     log::info!("Subsystem1 started.");
     tokio::select! {
-        _ =subsys.on_shutdown_requested() => (),
+        _ = subsys.on_shutdown_requested() => (),
         _ = sleep(Duration::from_secs(2)) => {
             panic!("Subsystem1 panicked!");
         }

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,0 +1,32 @@
+use tokio::sync::watch;
+
+pub struct Event {
+    receiver: watch::Receiver<bool>,
+}
+
+pub struct EventTrigger {
+    sender: watch::Sender<bool>,
+}
+impl EventTrigger {
+    pub fn set(&self) {
+        self.sender.send_replace(true);
+    }
+}
+
+impl Event {
+    pub fn create() -> (Self, EventTrigger) {
+        let (sender, receiver) = watch::channel(false);
+        (Self { receiver }, EventTrigger { sender })
+    }
+
+    pub fn get(&self) -> bool {
+        *self.receiver.borrow()
+    }
+
+    pub async fn wait(&self) {
+        let mut receiver = self.receiver.clone();
+        while !*receiver.borrow_and_update() {
+            receiver.changed().await.unwrap();
+        }
+    }
+}

--- a/src/event.rs
+++ b/src/event.rs
@@ -19,9 +19,9 @@ impl Event {
         (Self { receiver }, EventTrigger { sender })
     }
 
-    pub fn get(&self) -> bool {
-        *self.receiver.borrow()
-    }
+    // pub fn get(&self) -> bool {
+    //     *self.receiver.borrow()
+    // }
 
     pub async fn wait(&self) {
         let mut receiver = self.receiver.clone();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,6 +81,7 @@
 //! to initiate a shutdown.
 //!
 
+pub mod event;
 mod exit_state;
 mod runner;
 mod shutdown_token;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,7 @@
 //! to initiate a shutdown.
 //!
 
-pub mod event;
+mod event;
 mod exit_state;
 mod runner;
 mod shutdown_token;

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -68,7 +68,7 @@ impl SubsystemRunner {
 
         Self {
             outer_joinhandle,
-            request_cancellation: request_cancellation,
+            request_cancellation,
         }
     }
 

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -1,25 +1,91 @@
-use crate::SubsystemHandle;
+use crate::{
+    event::{Event, EventTrigger},
+    ShutdownToken, SubsystemHandle,
+};
 use anyhow::Result;
-use std::future::Future;
+use std::{future::Future, slice::Join};
+use tokio::task::{JoinError, JoinHandle};
 
-pub async fn run_subsystem<
-    Fut: Future<Output = Result<()>> + Send,
-    S: FnOnce(SubsystemHandle) -> Fut + Send,
->(
-    name: String,
-    subsystem: S,
-    subsystem_handle: SubsystemHandle,
-) -> Result<(), ()> {
-    let shutdown_token = subsystem_handle.shutdown_token().clone();
+pub struct SubsystemRunner {
+    shutdown_token: ShutdownToken,
+    outer_joinhandle: JoinHandle<Result<Result<(), ()>, JoinError>>,
+    request_cancellation: EventTrigger,
+}
 
-    let result = subsystem(subsystem_handle).await;
-    match result {
-        Ok(()) => Ok(()),
-        Err(e) => {
-            log::error!("Error in subsystem '{}': {:?}", name, e);
-            shutdown_token.shutdown();
-            Err(())
+impl SubsystemRunner {
+    async fn handle_subsystem(
+        mut inner_joinhandle: JoinHandle<Result<()>>,
+        shutdown_token: ShutdownToken,
+        name: String,
+        cancellation_requested: Event,
+    ) -> Result<Result<(), ()>, JoinError> {
+        let inner_joinhandle_ref = &mut inner_joinhandle;
+        let result = tokio::select! {
+            result = inner_joinhandle_ref => {
+                match result {
+                    Ok(Ok(())) => {Ok(Ok(()))},
+                    Ok(Err(e)) => {
+                        log::error!("Error in subsystem '{}': {:?}", name, e);
+                        shutdown_token.shutdown();
+                        Ok(Err(()))
+                    },
+                    Err(e) => {
+                        log::error!("Error in subsystem '{}': {:?}", name, e);
+                        shutdown_token.shutdown();
+                        Err(e)
+                    }
+                }
+            },
+            _ = cancellation_requested.wait() => {
+                // If cancellation is requested, cancel the subsystem and query its return
+                // value
+                inner_joinhandle_ref.abort();
+                match inner_joinhandle_ref.await {
+                    Ok(Ok(())) => {Ok(Ok(()))},
+                    Ok(Err(e)) => {
+                        log::error!("Error in subsystem '{}': {:?}", name, e);
+                        Ok(Err(()))
+                    },
+                    Err(e) => {
+                        Err(e)
+                    }
+                }
+            }
+        };
+
+        result
+    }
+
+    pub fn new<Fut: 'static + Future<Output = Result<()>> + Send>(
+        name: String,
+        shutdown_token: ShutdownToken,
+        subsystem_future: Fut,
+    ) -> Self {
+        let (cancellation_requested, request_cancellation) = Event::create();
+
+        // Spawn to nested tasks.
+        // This enables us to catch panics, as panics get returned through a JoinHandle.
+        let mut inner_joinhandle = tokio::spawn(subsystem_future);
+        let outer_joinhandle = tokio::spawn(Self::handle_subsystem(
+            inner_joinhandle,
+            shutdown_token.clone(),
+            name,
+            cancellation_requested,
+        ));
+
+        Self {
+            shutdown_token,
+            outer_joinhandle,
+            request_cancellation: request_cancellation,
         }
+    }
+
+    pub async fn join(&mut self) -> Result<Result<(), ()>, JoinError> {
+        (&mut self.outer_joinhandle).await?
+    }
+
+    pub fn abort(&self) {
+        self.request_cancellation.set();
     }
 }
 

--- a/src/subsystem.rs
+++ b/src/subsystem.rs
@@ -12,7 +12,7 @@ use tokio::task::JoinHandle;
 use crate::exit_state::join_shutdown_results;
 use crate::exit_state::ShutdownResults;
 use crate::exit_state::SubprocessExitState;
-use crate::runner::run_subsystem;
+use crate::runner::SubsystemRunner;
 use crate::shutdown_token::ShutdownToken;
 
 #[cfg(doc)]
@@ -34,7 +34,7 @@ pub struct SubsystemHandle {
 
 struct SubsystemDescriptor {
     data: Arc<SubsystemData>,
-    joinhandle: JoinHandle<Result<(), ()>>,
+    subsystem_runner: SubsystemRunner,
 }
 
 impl SubsystemData {
@@ -51,21 +51,17 @@ impl SubsystemData {
     ///
     /// If a shutdown is already running, self.subsystems will be 'None',
     /// and the newly spawned subsystem will be cancelled.
-    pub fn add_subsystem(
-        &self,
-        subsystem: Arc<SubsystemData>,
-        joinhandle: JoinHandle<Result<(), ()>>,
-    ) {
+    pub fn add_subsystem(&self, subsystem: Arc<SubsystemData>, subsystem_runner: SubsystemRunner) {
         match self.subsystems.lock().unwrap().as_mut() {
             Some(subsystems) => {
                 subsystems.push(SubsystemDescriptor {
-                    joinhandle,
+                    subsystem_runner,
                     data: subsystem,
                 });
             }
             None => {
                 log::error!("Unable to add subsystem, system already shutting down!");
-                joinhandle.abort();
+                subsystem_runner.abort();
             }
         }
     }
@@ -100,16 +96,20 @@ impl SubsystemData {
     pub async fn perform_shutdown(&self) -> ShutdownResults {
         let mut subsystems = self.prepare_shutdown().await;
 
-        let mut joinhandles = vec![];
+        let mut subsystem_runners = vec![];
         let mut subsystem_data = vec![];
-        for SubsystemDescriptor { joinhandle, data } in subsystems.iter_mut() {
-            joinhandles.push((data.name.clone(), joinhandle));
+        for SubsystemDescriptor {
+            subsystem_runner,
+            data,
+        } in subsystems.iter_mut()
+        {
+            subsystem_runners.push((data.name.clone(), subsystem_runner));
             subsystem_data.push(data);
         }
         let joinhandles_finished = join_all(
-            joinhandles
+            subsystem_runners
                 .iter_mut()
-                .map(|(name, joinhandle)| async { (name, joinhandle.await) }),
+                .map(|(name, subsystem_runner)| async { (name, subsystem_runner.join().await) }),
         );
         let subsystems_finished = join_all(
             subsystem_data
@@ -157,7 +157,7 @@ impl SubsystemData {
     pub async fn cancel_all_subsystems(&self) {
         let subsystems = self.prepare_shutdown().await;
         for subsystem in subsystems.iter() {
-            subsystem.joinhandle.abort();
+            subsystem.subsystem_runner.abort();
             subsystem.data.cancel_all_subsystems().await;
         }
     }
@@ -202,7 +202,7 @@ impl SubsystemHandle {
     /// ```
     ///
     pub fn start<
-        Fut: Future<Output = Result<()>> + Send,
+        Fut: 'static + Future<Output = Result<()>> + Send,
         S: 'static + FnOnce(SubsystemHandle) -> Fut + Send,
     >(
         &mut self,
@@ -224,11 +224,15 @@ impl SubsystemHandle {
         let subsystem_handle = SubsystemHandle::new(new_subsystem.clone());
 
         // Spawn new task
-        let join_handle =
-            tokio::spawn(async move { run_subsystem(name, subsystem, subsystem_handle).await });
+        let shutdown_token = subsystem_handle.shutdown_token().clone();
+        let subsystem_runner = SubsystemRunner::new(
+            name,
+            subsystem_handle.shutdown_token().clone(),
+            subsystem(subsystem_handle),
+        );
 
         // Store subsystem data
-        self.data.add_subsystem(new_subsystem, join_handle);
+        self.data.add_subsystem(new_subsystem, subsystem_runner);
 
         self
     }

--- a/src/subsystem.rs
+++ b/src/subsystem.rs
@@ -7,7 +7,6 @@ use futures::future::join;
 use futures::future::join_all;
 use std::future::Future;
 use std::sync::Mutex;
-use tokio::task::JoinHandle;
 
 use crate::exit_state::join_shutdown_results;
 use crate::exit_state::ShutdownResults;
@@ -224,7 +223,6 @@ impl SubsystemHandle {
         let subsystem_handle = SubsystemHandle::new(new_subsystem.clone());
 
         // Spawn new task
-        let shutdown_token = subsystem_handle.shutdown_token().clone();
         let subsystem_runner = SubsystemRunner::new(
             name,
             subsystem_handle.shutdown_token().clone(),

--- a/src/toplevel.rs
+++ b/src/toplevel.rs
@@ -46,9 +46,6 @@ pub struct Toplevel {
 
 impl Drop for Toplevel {
     fn drop(&mut self) {
-        // Restore panic hook to its original state
-        let _ = panic::take_hook();
-
         // Unregister the toplevel object to make sure another one can be created in future
         if let Ok(true) =
             TOPLEVEL_EXISTS.compare_exchange(true, false, Ordering::SeqCst, Ordering::SeqCst)
@@ -81,13 +78,6 @@ impl Toplevel {
         }
 
         let shutdown_token = create_shutdown_token();
-
-        // Register panic handler to trigger shutdown token
-        // let panic_shutdown_token = shutdown_token.clone();
-        // panic::set_hook(Box::new(move |panic_info| {
-        //     log::error!("ERROR: {}", panic_info);
-        //     panic_shutdown_token.shutdown();
-        // }));
 
         let subsys_data = Arc::new(SubsystemData::new("", shutdown_token));
         let subsys_handle = SubsystemHandle::new(subsys_data.clone());

--- a/src/toplevel.rs
+++ b/src/toplevel.rs
@@ -83,11 +83,11 @@ impl Toplevel {
         let shutdown_token = create_shutdown_token();
 
         // Register panic handler to trigger shutdown token
-        let panic_shutdown_token = shutdown_token.clone();
-        panic::set_hook(Box::new(move |panic_info| {
-            log::error!("ERROR: {}", panic_info);
-            panic_shutdown_token.shutdown();
-        }));
+        // let panic_shutdown_token = shutdown_token.clone();
+        // panic::set_hook(Box::new(move |panic_info| {
+        //     log::error!("ERROR: {}", panic_info);
+        //     panic_shutdown_token.shutdown();
+        // }));
 
         let subsys_data = Arc::new(SubsystemData::new("", shutdown_token));
         let subsys_handle = SubsystemHandle::new(subsys_data.clone());
@@ -121,7 +121,7 @@ impl Toplevel {
     /// * `subsystem` - The subsystem to be started
     ///
     pub fn start<
-        Fut: Future<Output = Result<()>> + Send,
+        Fut: 'static + Future<Output = Result<()>> + Send,
         S: 'static + FnOnce(SubsystemHandle) -> Fut + Send,
     >(
         self,

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -412,29 +412,3 @@ async fn double_panic_does_not_stop_graceful_shutdown() {
 
     assert!(subsys_finished.get());
 }
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
-async fn creating_two_toplevels_throws_an_error() {
-    let (subsys_finished, set_subsys_finished) = Event::create();
-
-    let subsys1 = move |_subsys: SubsystemHandle| async move {
-        let _nested_toplevel = Toplevel::new();
-        set_subsys_finished();
-        Ok(())
-    };
-
-    let toplevel = Toplevel::new().start("subsys", subsys1);
-    let shutdown_token = toplevel.get_shutdown_token().clone();
-
-    tokio::join!(
-        async {
-            let result = toplevel.wait_for_shutdown(Duration::from_millis(500)).await;
-            assert!(result.is_err());
-        },
-        async {
-            sleep(Duration::from_millis(100)).await;
-            shutdown_token.shutdown();
-        }
-    );
-    assert!(!subsys_finished.get());
-}


### PR DESCRIPTION
- Remove global panic hook
- Catch panics by watching JoinHandles instead
- Add example for an auto-restarting subsystem, as discussed in https://github.com/Finomnis/tokio-graceful-shutdown/issues/5