### PR TITLE
Reduce rust version to 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tokio-graceful-shutdown"
 authors = ["Finomnis <finomnis@gmail.com>"]
 version = "0.4.1"
-edition = "2021"
+edition = "2018"
 license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/Finomnis/tokio-graceful-shutdown"

--- a/src/subsystem/data.rs
+++ b/src/subsystem/data.rs
@@ -102,7 +102,9 @@ impl SubsystemData {
         let joinhandles_finished = join_all(
             subsystem_runners
                 .iter_mut()
-                .map(|(name, subsystem_runner)| async move { (name, subsystem_runner.join().await) }),
+                .map(
+                    |(name, subsystem_runner)| async move { (name, subsystem_runner.join().await) },
+                ),
         );
         let subsystems_finished = join_all(
             subsystem_data

--- a/src/subsystem/data.rs
+++ b/src/subsystem/data.rs
@@ -102,7 +102,7 @@ impl SubsystemData {
         let joinhandles_finished = join_all(
             subsystem_runners
                 .iter_mut()
-                .map(|(name, subsystem_runner)| async { (name, subsystem_runner.join().await) }),
+                .map(|(name, subsystem_runner)| async move { (name, subsystem_runner.join().await) }),
         );
         let subsystems_finished = join_all(
             subsystem_data


### PR DESCRIPTION
This increases compatibility with legacy projects.

Fixes https://github.com/Finomnis/tokio-graceful-shutdown/issues/9.