### PR TITLE
Remove mutability requirement from SubsystemHandle::start

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 Cargo.lock
+.idea

--- a/examples/06_nested_subsystems.rs
+++ b/examples/06_nested_subsystems.rs
@@ -6,7 +6,7 @@ use env_logger::{Builder, Env};
 use tokio::time::{sleep, Duration};
 use tokio_graceful_shutdown::{SubsystemHandle, Toplevel};
 
-async fn subsys1(mut subsys: SubsystemHandle) -> Result<()> {
+async fn subsys1(subsys: SubsystemHandle) -> Result<()> {
     subsys.start("Subsys2", subsys2);
     log::info!("Subsystem1 started.");
     subsys.on_shutdown_requested().await;

--- a/examples/07_nested_error.rs
+++ b/examples/07_nested_error.rs
@@ -7,7 +7,7 @@ use env_logger::{Builder, Env};
 use tokio::time::{sleep, Duration};
 use tokio_graceful_shutdown::{SubsystemHandle, Toplevel};
 
-async fn subsys1(mut subsys: SubsystemHandle) -> Result<()> {
+async fn subsys1(subsys: SubsystemHandle) -> Result<()> {
     subsys.start("Subsys2", subsys2);
     log::info!("Subsystem1 started.");
     subsys.on_shutdown_requested().await;

--- a/examples/08_panic_handling.rs
+++ b/examples/08_panic_handling.rs
@@ -9,7 +9,7 @@ use env_logger::{Builder, Env};
 use tokio::time::{sleep, Duration};
 use tokio_graceful_shutdown::{SubsystemHandle, Toplevel};
 
-async fn subsys1(mut subsys: SubsystemHandle) -> Result<()> {
+async fn subsys1(subsys: SubsystemHandle) -> Result<()> {
     subsys.start("Subsys2", subsys2);
     log::info!("Subsystem1 started.");
     subsys.on_shutdown_requested().await;

--- a/examples/11_double_panic.rs
+++ b/examples/11_double_panic.rs
@@ -12,7 +12,7 @@ use env_logger::{Builder, Env};
 use tokio::time::{sleep, Duration};
 use tokio_graceful_shutdown::{SubsystemHandle, Toplevel};
 
-async fn subsys1(mut subsys: SubsystemHandle) -> Result<()> {
+async fn subsys1(subsys: SubsystemHandle) -> Result<()> {
     subsys.start("Subsys2", subsys2);
     subsys.start("Subsys3", subsys3);
     log::info!("Subsystem1 started.");

--- a/examples/13_partial_shutdown.rs
+++ b/examples/13_partial_shutdown.rs
@@ -15,7 +15,7 @@ async fn subsys3(subsys: SubsystemHandle) -> Result<()> {
     Ok(())
 }
 
-async fn subsys2(mut subsys: SubsystemHandle) -> Result<()> {
+async fn subsys2(subsys: SubsystemHandle) -> Result<()> {
     log::info!("Subsys2 started.");
     subsys.start("Subsys3", subsys3);
     subsys.on_shutdown_requested().await;
@@ -23,7 +23,7 @@ async fn subsys2(mut subsys: SubsystemHandle) -> Result<()> {
     Ok(())
 }
 
-async fn subsys1(mut subsys: SubsystemHandle) -> Result<()> {
+async fn subsys1(subsys: SubsystemHandle) -> Result<()> {
     // This subsystem shuts down the nested subsystem after 5 seconds.
     log::info!("Subsys1 started.");
 

--- a/examples/14_partial_shutdown_error.rs
+++ b/examples/14_partial_shutdown_error.rs
@@ -15,7 +15,7 @@ async fn subsys3(subsys: SubsystemHandle) -> Result<()> {
     panic!("Subsystem3 threw an error!")
 }
 
-async fn subsys2(mut subsys: SubsystemHandle) -> Result<()> {
+async fn subsys2(subsys: SubsystemHandle) -> Result<()> {
     log::info!("Subsys2 started.");
     subsys.start("Subsys3", subsys3);
     subsys.on_shutdown_requested().await;
@@ -23,7 +23,7 @@ async fn subsys2(mut subsys: SubsystemHandle) -> Result<()> {
     Ok(())
 }
 
-async fn subsys1(mut subsys: SubsystemHandle) -> Result<()> {
+async fn subsys1(subsys: SubsystemHandle) -> Result<()> {
     // This subsystem shuts down the nested subsystem after 5 seconds.
     log::info!("Subsys1 started.");
 

--- a/src/subsystem/handle.rs
+++ b/src/subsystem/handle.rs
@@ -44,7 +44,7 @@ impl SubsystemHandle {
     ///     Ok(())
     /// }
     ///
-    /// async fn my_subsystem(mut subsys: SubsystemHandle) -> Result<()> {
+    /// async fn my_subsystem(subsys: SubsystemHandle) -> Result<()> {
     ///     // start a nested subsystem
     ///     subsys.start("Nested", nested_subsystem);
     ///
@@ -57,7 +57,7 @@ impl SubsystemHandle {
         Fut: 'static + Future<Output = Result<()>> + Send,
         S: 'static + FnOnce(SubsystemHandle) -> Fut + Send,
     >(
-        &mut self,
+        &self,
         name: &'static str,
         subsystem: S,
     ) -> NestedSubsystem {
@@ -189,7 +189,7 @@ impl SubsystemHandle {
     ///     Ok(())
     /// }
     ///
-    /// async fn subsystem(mut subsys: SubsystemHandle) -> Result<()> {
+    /// async fn subsystem(subsys: SubsystemHandle) -> Result<()> {
     ///     // This subsystem waits for one second and then performs a partial shutdown
     ///
     ///     // Spawn nested subsystem

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -177,7 +177,7 @@ async fn nested_subsystem_receives_shutdown() {
         Ok(())
     };
 
-    let subsystem = |mut subsys: SubsystemHandle| async move {
+    let subsystem = |subsys: SubsystemHandle| async move {
         subsys.start("nested", nested_subsystem);
         subsys.on_shutdown_requested().await;
         Ok(())
@@ -209,7 +209,7 @@ async fn nested_subsystem_error_propagates() {
 
     let nested_subsystem = |_subsys: SubsystemHandle| async move { Err(anyhow!("Error!")) };
 
-    let subsystem = move |mut subsys: SubsystemHandle| async move {
+    let subsystem = move |subsys: SubsystemHandle| async move {
         subsys.start("nested", nested_subsystem);
         subsys.on_shutdown_requested().await;
         Ok(())
@@ -246,7 +246,7 @@ async fn panic_gets_handled_correctly() {
         panic!("Error!");
     };
 
-    let subsystem = move |mut subsys: SubsystemHandle| async move {
+    let subsystem = move |subsys: SubsystemHandle| async move {
         subsys.start("nested", nested_subsystem);
         subsys.on_shutdown_requested().await;
         Ok(())
@@ -386,7 +386,7 @@ async fn spawning_task_during_shutdown_causes_task_to_be_cancelled() {
         Ok(())
     };
 
-    let subsystem = move |mut subsys: SubsystemHandle| async move {
+    let subsystem = move |subsys: SubsystemHandle| async move {
         subsys.on_shutdown_requested().await;
         sleep(Duration::from_millis(100)).await;
         subsys.start("Nested", nested);
@@ -451,7 +451,7 @@ async fn double_panic_does_not_stop_graceful_shutdown() {
         panic!("Subsystem2 panicked!")
     };
 
-    let subsys1 = move |mut subsys: SubsystemHandle| async move {
+    let subsys1 = move |subsys: SubsystemHandle| async move {
         subsys.start("Subsys2", subsys2);
         subsys.start("Subsys3", subsys3);
         subsys.on_shutdown_requested().await;
@@ -539,7 +539,7 @@ async fn partial_shutdown_request_stops_nested_subsystems() {
         set_subsys3_finished();
         Ok(())
     };
-    let subsys2 = move |mut subsys: SubsystemHandle| async move {
+    let subsys2 = move |subsys: SubsystemHandle| async move {
         set_subsys2_started();
         subsys.start("subsys3", subsys3);
         subsys.on_shutdown_requested().await;
@@ -547,7 +547,7 @@ async fn partial_shutdown_request_stops_nested_subsystems() {
         Ok(())
     };
 
-    let subsys1 = move |mut subsys: SubsystemHandle| async move {
+    let subsys1 = move |subsys: SubsystemHandle| async move {
         set_subsys1_started();
         let nested_subsys = subsys.start("subsys2", subsys2);
         sleep(Duration::from_millis(200)).await;
@@ -600,7 +600,7 @@ async fn partial_shutdown_panic_gets_propagated_correctly() {
         panic!("Nested panicked.");
     };
 
-    let subsys1 = move |mut subsys: SubsystemHandle| async move {
+    let subsys1 = move |subsys: SubsystemHandle| async move {
         let handle = subsys.start("nested", nested_subsys);
         sleep(Duration::from_millis(100)).await;
         let result = subsys.perform_partial_shutdown(handle).await;
@@ -636,7 +636,7 @@ async fn partial_shutdown_error_gets_propagated_correctly() {
         Err(anyhow!("nested failed."))
     };
 
-    let subsys1 = move |mut subsys: SubsystemHandle| async move {
+    let subsys1 = move |subsys: SubsystemHandle| async move {
         let handle = subsys.start("nested", nested_subsys);
         sleep(Duration::from_millis(100)).await;
         let result = subsys.perform_partial_shutdown(handle).await;
@@ -672,7 +672,7 @@ async fn partial_shutdown_during_program_shutdown_causes_error() {
         Ok(())
     };
 
-    let subsys1 = move |mut subsys: SubsystemHandle| async move {
+    let subsys1 = move |subsys: SubsystemHandle| async move {
         let handle = subsys.start("nested", nested_subsys);
         sleep(Duration::from_millis(100)).await;
 
@@ -715,7 +715,7 @@ async fn partial_shutdown_on_wrong_parent_causes_error() {
         Ok(())
     };
 
-    let subsys1 = move |mut subsys: SubsystemHandle| async move {
+    let subsys1 = move |subsys: SubsystemHandle| async move {
         let handle = subsys.start("nested", nested_subsys);
 
         sleep(Duration::from_millis(100)).await;


### PR DESCRIPTION
Start doesn't require mutability so we can remove that restriction. This way the subsystem handle can
be shared by cloning it directly without having to wrap it in a type that provides mutability. 
