### PR TITLE
Remove anyhow from signatures.

### DIFF
--- a/examples/01_normal_shutdown.rs
+++ b/examples/01_normal_shutdown.rs
@@ -7,11 +7,12 @@
 //! If custom arguments for the subsystem coroutines are required,
 //! a struct has to be used instead, as seen in other examples.
 
+use anyhow::Result;
 use env_logger::{Builder, Env};
 use tokio::time::{sleep, Duration};
-use tokio_graceful_shutdown::{Error, SubsystemHandle, Toplevel};
+use tokio_graceful_shutdown::{SubsystemHandle, Toplevel};
 
-async fn subsys1(subsys: SubsystemHandle) -> Result<(), Error> {
+async fn subsys1(subsys: SubsystemHandle) -> Result<()> {
     log::info!("Subsystem1 started.");
     subsys.on_shutdown_requested().await;
     log::info!("Shutting down Subsystem1 ...");
@@ -20,7 +21,7 @@ async fn subsys1(subsys: SubsystemHandle) -> Result<(), Error> {
     Ok(())
 }
 
-async fn subsys2(subsys: SubsystemHandle) -> Result<(), Error> {
+async fn subsys2(subsys: SubsystemHandle) -> Result<()> {
     log::info!("Subsystem2 started.");
     subsys.on_shutdown_requested().await;
     log::info!("Shutting down Subsystem2 ...");
@@ -30,7 +31,7 @@ async fn subsys2(subsys: SubsystemHandle) -> Result<(), Error> {
 }
 
 #[tokio::main]
-async fn main() -> Result<(), Error> {
+async fn main() -> Result<()> {
     // Init logging
     Builder::from_env(Env::default().default_filter_or("debug")).init();
 

--- a/examples/02_structs.rs
+++ b/examples/02_structs.rs
@@ -4,7 +4,7 @@
 use anyhow::Result;
 use env_logger::{Builder, Env};
 use tokio::time::{sleep, Duration};
-use tokio_graceful_shutdown::{Error, SubsystemHandle, Toplevel};
+use tokio_graceful_shutdown::{SubsystemHandle, Toplevel};
 
 struct Subsystem1 {
     arg: u32,
@@ -22,7 +22,7 @@ impl Subsystem1 {
 }
 
 #[tokio::main]
-async fn main() -> Result<(), Error> {
+async fn main() -> Result<()> {
     // Init logging
     Builder::from_env(Env::default().default_filter_or("debug")).init();
 

--- a/examples/03_shutdown_timeout.rs
+++ b/examples/03_shutdown_timeout.rs
@@ -4,11 +4,12 @@
 //! so the subsystem gets cancelled and the program returns an appropriate
 //! error code.
 
+use anyhow::Result;
 use env_logger::{Builder, Env};
 use tokio::time::{sleep, Duration};
-use tokio_graceful_shutdown::{Error, SubsystemHandle, Toplevel};
+use tokio_graceful_shutdown::{SubsystemHandle, Toplevel};
 
-async fn subsys1(subsys: SubsystemHandle) -> Result<(), Error> {
+async fn subsys1(subsys: SubsystemHandle) -> Result<()> {
     log::info!("Subsystem1 started.");
     subsys.on_shutdown_requested().await;
     log::info!("Shutting down Subsystem1 ...");
@@ -18,7 +19,7 @@ async fn subsys1(subsys: SubsystemHandle) -> Result<(), Error> {
 }
 
 #[tokio::main]
-async fn main() -> Result<(), Error> {
+async fn main() -> Result<()> {
     // Init logging
     Builder::from_env(Env::default().default_filter_or("debug")).init();
 

--- a/examples/04_subsystem_finished.rs
+++ b/examples/04_subsystem_finished.rs
@@ -4,11 +4,12 @@
 //! Returning Ok(()) from a subsystem indicates that the subsystem
 //! stopped intentionally, and no further measures by the runtime are performed.
 
+use anyhow::Result;
 use env_logger::{Builder, Env};
 use tokio::time::{sleep, Duration};
-use tokio_graceful_shutdown::{Error, SubsystemHandle, Toplevel};
+use tokio_graceful_shutdown::{SubsystemHandle, Toplevel};
 
-async fn subsys1(_subsys: SubsystemHandle) -> Result<(), Error> {
+async fn subsys1(_subsys: SubsystemHandle) -> Result<()> {
     log::info!("Subsystem1 started.");
     sleep(Duration::from_millis(500)).await;
     log::info!("Subsystem1 stopped.");
@@ -18,7 +19,7 @@ async fn subsys1(_subsys: SubsystemHandle) -> Result<(), Error> {
 }
 
 #[tokio::main]
-async fn main() -> Result<(), Error> {
+async fn main() -> Result<()> {
     // Init logging
     Builder::from_env(Env::default().default_filter_or("debug")).init();
 

--- a/examples/05_subsystem_finished_with_error.rs
+++ b/examples/05_subsystem_finished_with_error.rs
@@ -6,21 +6,22 @@
 //! As expected, this is a graceful shutdown, giving other subsystems
 //! the chance to also shut down gracefully.
 
+use anyhow::{anyhow, Result};
 use env_logger::{Builder, Env};
 use tokio::time::{sleep, Duration};
-use tokio_graceful_shutdown::{Error, SubsystemHandle, Toplevel};
+use tokio_graceful_shutdown::{SubsystemHandle, Toplevel};
 
-async fn subsys1(_subsys: SubsystemHandle) -> Result<(), Error> {
+async fn subsys1(_subsys: SubsystemHandle) -> Result<()> {
     log::info!("Subsystem1 started.");
     sleep(Duration::from_millis(500)).await;
     log::info!("Subsystem1 stopped.");
 
     // Task ends with an error. This should cause the main program to shutdown.
-    Err(anyhow::anyhow!("Subsystem1 threw an error.").into())
+    Err(anyhow!("Subsystem1 threw an error."))
 }
 
 #[tokio::main]
-async fn main() -> Result<(), Error> {
+async fn main() -> Result<()> {
     // Init logging
     Builder::from_env(Env::default().default_filter_or("debug")).init();
 

--- a/examples/06_nested_subsystems.rs
+++ b/examples/06_nested_subsystems.rs
@@ -1,11 +1,12 @@
 //! This example demonstrates how one subsystem can launch another
 //! nested subsystem.
 
+use anyhow::Result;
 use env_logger::{Builder, Env};
 use tokio::time::{sleep, Duration};
-use tokio_graceful_shutdown::{Error, SubsystemHandle, Toplevel};
+use tokio_graceful_shutdown::{SubsystemHandle, Toplevel};
 
-async fn subsys1(subsys: SubsystemHandle) -> Result<(), Error> {
+async fn subsys1(subsys: SubsystemHandle) -> Result<()> {
     subsys.start("Subsys2", subsys2);
     log::info!("Subsystem1 started.");
     subsys.on_shutdown_requested().await;
@@ -15,7 +16,7 @@ async fn subsys1(subsys: SubsystemHandle) -> Result<(), Error> {
     Ok(())
 }
 
-async fn subsys2(subsys: SubsystemHandle) -> Result<(), Error> {
+async fn subsys2(subsys: SubsystemHandle) -> Result<()> {
     log::info!("Subsystem2 started.");
     subsys.on_shutdown_requested().await;
     log::info!("Shutting down Subsystem2 ...");
@@ -25,7 +26,7 @@ async fn subsys2(subsys: SubsystemHandle) -> Result<(), Error> {
 }
 
 #[tokio::main]
-async fn main() -> Result<(), Error> {
+async fn main() -> Result<()> {
     // Init logging
     Builder::from_env(Env::default().default_filter_or("debug")).init();
 

--- a/examples/07_nested_error.rs
+++ b/examples/07_nested_error.rs
@@ -2,11 +2,12 @@
 //! a graceful shutdown is performed and other subsystems get the chance
 //! to clean up.
 
+use anyhow::{anyhow, Result};
 use env_logger::{Builder, Env};
 use tokio::time::{sleep, Duration};
-use tokio_graceful_shutdown::{Error, SubsystemHandle, Toplevel};
+use tokio_graceful_shutdown::{SubsystemHandle, Toplevel};
 
-async fn subsys1(subsys: SubsystemHandle) -> Result<(), Error> {
+async fn subsys1(subsys: SubsystemHandle) -> Result<()> {
     subsys.start("Subsys2", subsys2);
     log::info!("Subsystem1 started.");
     subsys.on_shutdown_requested().await;
@@ -16,15 +17,15 @@ async fn subsys1(subsys: SubsystemHandle) -> Result<(), Error> {
     Ok(())
 }
 
-async fn subsys2(_subsys: SubsystemHandle) -> Result<(), Error> {
+async fn subsys2(_subsys: SubsystemHandle) -> Result<()> {
     log::info!("Subsystem2 started.");
     sleep(Duration::from_millis(500)).await;
 
-    Err(anyhow::anyhow!("Subsystem2 threw an error.").into())
+    Err(anyhow!("Subsystem2 threw an error."))
 }
 
 #[tokio::main]
-async fn main() -> Result<(), Error> {
+async fn main() -> Result<()> {
     // Init logging
     Builder::from_env(Env::default().default_filter_or("debug")).init();
 

--- a/examples/08_panic_handling.rs
+++ b/examples/08_panic_handling.rs
@@ -4,11 +4,12 @@
 //! A normal program shutdown is performed, and other subsystems get the
 //! chance to clean up their work.
 
+use anyhow::Result;
 use env_logger::{Builder, Env};
 use tokio::time::{sleep, Duration};
-use tokio_graceful_shutdown::{Error, SubsystemHandle, Toplevel};
+use tokio_graceful_shutdown::{SubsystemHandle, Toplevel};
 
-async fn subsys1(subsys: SubsystemHandle) -> Result<(), Error> {
+async fn subsys1(subsys: SubsystemHandle) -> Result<()> {
     subsys.start("Subsys2", subsys2);
     log::info!("Subsystem1 started.");
     subsys.on_shutdown_requested().await;
@@ -18,7 +19,7 @@ async fn subsys1(subsys: SubsystemHandle) -> Result<(), Error> {
     Ok(())
 }
 
-async fn subsys2(_subsys: SubsystemHandle) -> Result<(), Error> {
+async fn subsys2(_subsys: SubsystemHandle) -> Result<()> {
     log::info!("Subsystem2 started.");
     sleep(Duration::from_millis(500)).await;
 
@@ -26,7 +27,7 @@ async fn subsys2(_subsys: SubsystemHandle) -> Result<(), Error> {
 }
 
 #[tokio::main]
-async fn main() -> Result<(), Error> {
+async fn main() -> Result<()> {
     // Init logging
     Builder::from_env(Env::default().default_filter_or("debug")).init();
 

--- a/examples/09_task_cancellation.rs
+++ b/examples/09_task_cancellation.rs
@@ -5,9 +5,10 @@
 //! tasks once one of them finishes. This can be used to cancel
 //! tasks once the shutdown was initiated.
 
+use anyhow::Result;
 use env_logger::{Builder, Env};
 use tokio::time::{sleep, Duration};
-use tokio_graceful_shutdown::{Error, SubsystemHandle, Toplevel};
+use tokio_graceful_shutdown::{SubsystemHandle, Toplevel};
 
 struct CountdownSubsystem {}
 impl CountdownSubsystem {
@@ -22,7 +23,7 @@ impl CountdownSubsystem {
         }
     }
 
-    async fn run(self, subsys: SubsystemHandle) -> Result<(), Error> {
+    async fn run(self, subsys: SubsystemHandle) -> Result<()> {
         log::info!("Starting countdown ...");
 
         tokio::select! {
@@ -39,7 +40,7 @@ impl CountdownSubsystem {
 }
 
 #[tokio::main]
-async fn main() -> Result<(), Error> {
+async fn main() -> Result<()> {
     // Init logging
     Builder::from_env(Env::default().default_filter_or("debug")).init();
 

--- a/examples/10_request_shutdown.rs
+++ b/examples/10_request_shutdown.rs
@@ -1,9 +1,10 @@
 //! This example demonstrates how a subsystem can initiate
 //! a shutdown.
 
+use anyhow::Result;
 use env_logger::{Builder, Env};
 use tokio::time::{sleep, Duration};
-use tokio_graceful_shutdown::{Error, SubsystemHandle, Toplevel};
+use tokio_graceful_shutdown::{SubsystemHandle, Toplevel};
 
 struct CountdownSubsystem {}
 impl CountdownSubsystem {
@@ -18,7 +19,7 @@ impl CountdownSubsystem {
         }
     }
 
-    async fn run(self, subsys: SubsystemHandle) -> Result<(), Error> {
+    async fn run(self, subsys: SubsystemHandle) -> Result<()> {
         tokio::select! {
             _ = subsys.on_shutdown_requested() => {
                 log::info!("Countdown cancelled.");
@@ -33,7 +34,7 @@ impl CountdownSubsystem {
 }
 
 #[tokio::main]
-async fn main() -> Result<(), Error> {
+async fn main() -> Result<()> {
     // Init logging
     Builder::from_env(Env::default().default_filter_or("debug")).init();
 

--- a/examples/11_double_panic.rs
+++ b/examples/11_double_panic.rs
@@ -7,11 +7,12 @@
 //! There is no real programming knowledge to be gained here, this example is just
 //! to demonstrate the robustness of the system.
 
+use anyhow::Result;
 use env_logger::{Builder, Env};
 use tokio::time::{sleep, Duration};
-use tokio_graceful_shutdown::{Error, SubsystemHandle, Toplevel};
+use tokio_graceful_shutdown::{SubsystemHandle, Toplevel};
 
-async fn subsys1(subsys: SubsystemHandle) -> Result<(), Error> {
+async fn subsys1(subsys: SubsystemHandle) -> Result<()> {
     subsys.start("Subsys2", subsys2);
     subsys.start("Subsys3", subsys3);
     log::info!("Subsystem1 started.");
@@ -21,14 +22,14 @@ async fn subsys1(subsys: SubsystemHandle) -> Result<(), Error> {
     panic!("Subsystem1 panicked!");
 }
 
-async fn subsys2(_subsys: SubsystemHandle) -> Result<(), Error> {
+async fn subsys2(_subsys: SubsystemHandle) -> Result<()> {
     log::info!("Subsystem2 started.");
     sleep(Duration::from_millis(500)).await;
 
     panic!("Subsystem2 panicked!")
 }
 
-async fn subsys3(subsys: SubsystemHandle) -> Result<(), Error> {
+async fn subsys3(subsys: SubsystemHandle) -> Result<()> {
     log::info!("Subsystem3 started.");
     subsys.on_shutdown_requested().await;
     log::info!("Shutting down Subsystem3 ...");
@@ -38,7 +39,7 @@ async fn subsys3(subsys: SubsystemHandle) -> Result<(), Error> {
 }
 
 #[tokio::main(flavor = "current_thread")]
-async fn main() -> Result<(), Error> {
+async fn main() -> Result<()> {
     // Init logging
     Builder::from_env(Env::default().default_filter_or("debug")).init();
 

--- a/examples/12_subsystem_auto_restart.rs
+++ b/examples/12_subsystem_auto_restart.rs
@@ -4,11 +4,12 @@
 //! This isn't really a usecase related to this library, but seems to be used regularly,
 //! so I included it anyway.
 
+use anyhow::Result;
 use env_logger::{Builder, Env};
 use tokio::time::{sleep, Duration};
-use tokio_graceful_shutdown::{Error, SubsystemHandle, Toplevel};
+use tokio_graceful_shutdown::{SubsystemHandle, Toplevel};
 
-async fn subsys1(subsys: SubsystemHandle) -> Result<(), Error> {
+async fn subsys1(subsys: SubsystemHandle) -> Result<()> {
     // This subsystem panics every two seconds.
     // It should get restarted constantly.
 
@@ -24,7 +25,7 @@ async fn subsys1(subsys: SubsystemHandle) -> Result<(), Error> {
     Ok(())
 }
 
-async fn subsys1_with_autorestart(subsys: SubsystemHandle) -> Result<(), Error> {
+async fn subsys1_with_autorestart(subsys: SubsystemHandle) -> Result<()> {
     loop {
         let mut joinhandle = tokio::spawn(subsys1(subsys.clone()));
         let joinhandle_ref = &mut joinhandle;
@@ -46,7 +47,7 @@ async fn subsys1_with_autorestart(subsys: SubsystemHandle) -> Result<(), Error> 
 }
 
 #[tokio::main(flavor = "current_thread")]
-async fn main() -> Result<(), Error> {
+async fn main() -> Result<()> {
     // Init logging
     Builder::from_env(Env::default().default_filter_or("debug")).init();
 

--- a/examples/13_partial_shutdown.rs
+++ b/examples/13_partial_shutdown.rs
@@ -3,18 +3,19 @@
 //! Subsys1 will perform a partial shutdown after 5 seconds, which will in turn
 //! shut down Subsys2 and Subsys3, leaving Subsys1 running.
 
+use anyhow::Result;
 use env_logger::{Builder, Env};
 use tokio::time::{sleep, Duration};
-use tokio_graceful_shutdown::{Error, SubsystemHandle, Toplevel};
+use tokio_graceful_shutdown::{SubsystemHandle, Toplevel};
 
-async fn subsys3(subsys: SubsystemHandle) -> Result<(), Error> {
+async fn subsys3(subsys: SubsystemHandle) -> Result<()> {
     log::info!("Subsys3 started.");
     subsys.on_shutdown_requested().await;
     log::info!("Subsys3 stopped.");
     Ok(())
 }
 
-async fn subsys2(subsys: SubsystemHandle) -> Result<(), Error> {
+async fn subsys2(subsys: SubsystemHandle) -> Result<()> {
     log::info!("Subsys2 started.");
     subsys.start("Subsys3", subsys3);
     subsys.on_shutdown_requested().await;
@@ -22,7 +23,7 @@ async fn subsys2(subsys: SubsystemHandle) -> Result<(), Error> {
     Ok(())
 }
 
-async fn subsys1(subsys: SubsystemHandle) -> Result<(), Error> {
+async fn subsys1(subsys: SubsystemHandle) -> Result<()> {
     // This subsystem shuts down the nested subsystem after 5 seconds.
     log::info!("Subsys1 started.");
 
@@ -46,7 +47,7 @@ async fn subsys1(subsys: SubsystemHandle) -> Result<(), Error> {
 }
 
 #[tokio::main(flavor = "current_thread")]
-async fn main() -> Result<(), Error> {
+async fn main() -> Result<()> {
     // Init logging
     Builder::from_env(Env::default().default_filter_or("debug")).init();
 

--- a/examples/14_partial_shutdown_error.rs
+++ b/examples/14_partial_shutdown_error.rs
@@ -4,17 +4,18 @@
 //! shutdown, but instead it will be delivered to the task that initiated
 //! the partial shutdown.
 
+use anyhow::Result;
 use env_logger::{Builder, Env};
 use tokio::time::{sleep, Duration};
-use tokio_graceful_shutdown::{Error, SubsystemHandle, Toplevel};
+use tokio_graceful_shutdown::{SubsystemHandle, Toplevel};
 
-async fn subsys3(subsys: SubsystemHandle) -> Result<(), Error> {
+async fn subsys3(subsys: SubsystemHandle) -> Result<()> {
     log::info!("Subsys3 started.");
     subsys.on_shutdown_requested().await;
     panic!("Subsystem3 threw an error!")
 }
 
-async fn subsys2(subsys: SubsystemHandle) -> Result<(), Error> {
+async fn subsys2(subsys: SubsystemHandle) -> Result<()> {
     log::info!("Subsys2 started.");
     subsys.start("Subsys3", subsys3);
     subsys.on_shutdown_requested().await;
@@ -22,7 +23,7 @@ async fn subsys2(subsys: SubsystemHandle) -> Result<(), Error> {
     Ok(())
 }
 
-async fn subsys1(subsys: SubsystemHandle) -> Result<(), Error> {
+async fn subsys1(subsys: SubsystemHandle) -> Result<()> {
     // This subsystem shuts down the nested subsystem after 5 seconds.
     log::info!("Subsys1 started.");
 
@@ -48,7 +49,7 @@ async fn subsys1(subsys: SubsystemHandle) -> Result<(), Error> {
 }
 
 #[tokio::main(flavor = "current_thread")]
-async fn main() -> Result<(), Error> {
+async fn main() -> Result<()> {
     // Init logging
     Builder::from_env(Env::default().default_filter_or("debug")).init();
 

--- a/examples/15_without_anyhow.rs
+++ b/examples/15_without_anyhow.rs
@@ -1,11 +1,11 @@
 //! This example shows how to use this library with std::error::Error instead of anyhow::Error
 
 use env_logger::{Builder, Env};
-use std::error::Error as StdError;
+use std::error::Error;
 use std::fmt;
 use std::result::Result;
 use tokio::time::{sleep, Duration};
-use tokio_graceful_shutdown::{Error, SubsystemHandle, Toplevel};
+use tokio_graceful_shutdown::{SubsystemHandle, Toplevel};
 
 #[derive(Debug, Clone)]
 struct MyError;
@@ -16,7 +16,7 @@ impl fmt::Display for MyError {
     }
 }
 
-impl StdError for MyError {}
+impl Error for MyError {}
 
 async fn subsys1(_subsys: SubsystemHandle) -> Result<(), MyError> {
     log::info!("Subsystem1 started.");
@@ -28,7 +28,7 @@ async fn subsys1(_subsys: SubsystemHandle) -> Result<(), MyError> {
 }
 
 #[tokio::main]
-async fn main() -> Result<(), Error> {
+async fn main() -> Result<(), Box<dyn Error>> {
     // Init logging
     Builder::from_env(Env::default().default_filter_or("debug")).init();
 

--- a/examples/hyper.rs
+++ b/examples/hyper.rs
@@ -3,9 +3,10 @@
 //!
 //! This example closely follows hyper's "hello" example.
 
+use anyhow::{anyhow, Result};
 use env_logger::{Builder, Env};
 use tokio::time::Duration;
-use tokio_graceful_shutdown::{Error, SubsystemHandle, Toplevel};
+use tokio_graceful_shutdown::{SubsystemHandle, Toplevel};
 
 use std::convert::Infallible;
 
@@ -16,7 +17,7 @@ async fn hello(_: Request<Body>) -> Result<Response<Body>, Infallible> {
     Ok(Response::new(Body::from("Hello World!")))
 }
 
-async fn hyper_subsystem(subsys: SubsystemHandle) -> Result<(), Error> {
+async fn hyper_subsystem(subsys: SubsystemHandle) -> Result<()> {
     // For every connection, we must make a `Service` to handle all
     // incoming HTTP requests on said connection.
     let make_svc = make_service_fn(|_conn| {
@@ -37,11 +38,11 @@ async fn hyper_subsystem(subsys: SubsystemHandle) -> Result<(), Error> {
     server
         .with_graceful_shutdown(subsys.on_shutdown_requested())
         .await
-        .or_else(|err| Err(err.into()))
+        .or_else(|err| Err(anyhow! {err}))
 }
 
 #[tokio::main]
-async fn main() -> Result<(), Error> {
+async fn main() -> Result<()> {
     // Init logging
     Builder::from_env(Env::default().default_filter_or("debug")).init();
 


### PR DESCRIPTION
This removes anyhow::Error from the future signatures. That way it's easier for people to integrate this crate without having to bring anyhow as a dependency.

I've updated all the examples.

Signed-off-by: David Calavera <david.calavera@gmail.com>