### PR TITLE
Toplevel sanity changes

### DIFF
--- a/src/toplevel.rs
+++ b/src/toplevel.rs
@@ -225,3 +225,9 @@ impl Toplevel {
         self.subsys_handle.global_shutdown_token()
     }
 }
+
+impl Drop for Toplevel {
+    fn drop(&mut self) {
+        self.subsys_data.cancel_all_subsystems();
+    }
+}

--- a/src/toplevel.rs
+++ b/src/toplevel.rs
@@ -44,6 +44,7 @@ use super::subsystem::SubsystemData;
 /// }
 /// ```
 ///
+#[must_use = "This toplevel must be consumed by calling `handle_shutdown_requests` on it."]
 pub struct Toplevel {
     subsys_data: Arc<SubsystemData>,
     subsys_handle: SubsystemHandle,


### PR DESCRIPTION
- Cancel subsystems when Toplevel is dropped
- Toplevel has to be consumed