### PR TITLE
FutureExt: Cancel on shutdown

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ tokio = { version = "1", default-features = false, features = [
 tokio-util = { version = "0.7.2", default-features = false }
 futures = "0.3"
 async-recursion = "1.0"
+pin-project-lite = "0.2"
 
 # For 'IntoSubsystem' trait
 async-trait = "0.1"

--- a/examples/09_task_cancellation.rs
+++ b/examples/09_task_cancellation.rs
@@ -8,9 +8,7 @@
 use env_logger::{Builder, Env};
 use miette::Result;
 use tokio::time::{sleep, Duration};
-use tokio_graceful_shutdown::{
-    errors::CancelOnShutdownError, FutureExt, SubsystemHandle, Toplevel,
-};
+use tokio_graceful_shutdown::{errors::CancelledByShutdown, FutureExt, SubsystemHandle, Toplevel};
 
 struct CountdownSubsystem {}
 impl CountdownSubsystem {
@@ -32,7 +30,7 @@ impl CountdownSubsystem {
             Ok(()) => {
                 log::info!("Countdown finished.");
             }
-            Err(CancelOnShutdownError::CancelledByShutdown) => {
+            Err(CancelledByShutdown) => {
                 log::info!("Countdown cancelled.");
             }
         }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -125,6 +125,15 @@ impl<ErrType: ErrTypeTraits> SubsystemError<ErrType> {
     }
 }
 
+/// This enum contains all the possible errors that could be returned
+/// by [`cancel_on_shutdown()`](crate::FutureExt::cancel_on_shutdown).
+#[derive(Error, Debug, Diagnostic)]
+pub enum CancelOnShutdownError {
+    /// At least one subsystem caused an error.
+    #[error("A shutdown request caused this task to be cancelled")]
+    CancelledByShutdown,
+}
+
 #[cfg(test)]
 mod tests {
     use crate::BoxedError;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -158,6 +158,7 @@ mod tests {
         examine_report(
             SubsystemError::Failed::<BoxedError>("".into(), SubsystemFailure("".into())).into(),
         );
+        examine_report(CancelledByShutdown.into());
     }
 
     #[test]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -125,7 +125,7 @@ impl<ErrType: ErrTypeTraits> SubsystemError<ErrType> {
     }
 }
 
-/// The error that happens when a task gets cancelled by
+/// The error that happens when a task gets cancelled through
 /// [`cancel_on_shutdown()`](crate::FutureExt::cancel_on_shutdown).
 #[derive(Error, Debug, Diagnostic)]
 #[error("A shutdown request caused this task to be cancelled")]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -125,14 +125,11 @@ impl<ErrType: ErrTypeTraits> SubsystemError<ErrType> {
     }
 }
 
-/// This enum contains all the possible errors that could be returned
-/// by [`cancel_on_shutdown()`](crate::FutureExt::cancel_on_shutdown).
+/// The error that happens when a task gets cancelled by
+/// [`cancel_on_shutdown()`](crate::FutureExt::cancel_on_shutdown).
 #[derive(Error, Debug, Diagnostic)]
-pub enum CancelOnShutdownError {
-    /// At least one subsystem caused an error.
-    #[error("A shutdown request caused this task to be cancelled")]
-    CancelledByShutdown,
-}
+#[error("A shutdown request caused this task to be cancelled")]
+pub struct CancelledByShutdown;
 
 #[cfg(test)]
 mod tests {

--- a/src/future_ext.rs
+++ b/src/future_ext.rs
@@ -55,7 +55,7 @@ pub trait FutureExt {
     ///
     /// # Arguments
     ///
-    /// * `subsys` - The [SubsystemHandle] to recieve the shutdown request from.
+    /// * `subsys` - The [SubsystemHandle] to receive the shutdown request from.
     ///
     /// # Examples
     /// ```

--- a/src/future_ext.rs
+++ b/src/future_ext.rs
@@ -44,21 +44,44 @@ where
     }
 }
 
-/// Extends the [std::future::Future] trait with a couple of useful utility functions
+/// Extends the [std::future::Future] trait with a couple of useful utility functions.
 pub trait FutureExt {
-    /// The type of the future
+    /// The type of the future.
     type Future;
 
     /// Cancels the future when a shutdown is initiated.
+    ///
+    /// ## Returns
+    ///
+    /// A future that resolves to the return value of the original future on success, or
+    /// [CancelledByShutdown] when a cancellation happened.
     ///
     /// # Arguments
     ///
     /// * `subsys` - The [SubsystemHandle] to recieve the shutdown request from.
     ///
-    /// # Returns
+    /// # Examples
+    /// ```
+    /// use miette::Result;
+    /// use tokio_graceful_shutdown::{errors::CancelledByShutdown, FutureExt, SubsystemHandle};
+    /// use tokio::time::{sleep, Duration};
     ///
-    /// A future that resolves to the return value of the original future on success, or a
-    /// [CancelOnShutdownError] when a cancellation happened.
+    /// async fn my_subsystem(subsys: SubsystemHandle) -> Result<()> {
+    ///     match sleep(Duration::from_secs(9001))
+    ///         .cancel_on_shutdown(&subsys)
+    ///         .await
+    ///     {
+    ///         Ok(()) => {
+    ///             println!("Sleep finished.");
+    ///         }
+    ///         Err(CancelledByShutdown) => {
+    ///             println!("Sleep got cancelled by shutdown.");
+    ///         }
+    ///     }
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
     fn cancel_on_shutdown(
         self,
         subsys: &SubsystemHandle,

--- a/src/future_ext.rs
+++ b/src/future_ext.rs
@@ -41,7 +41,7 @@ impl<T: std::future::Future> std::future::Future for CancelOnShutdownFuture<'_, 
     }
 }
 
-/// Extends the [std::future::Future] trait with a couple of useful utility functions.
+/// Extends the [std::future::Future] trait with a useful utility functions.
 pub trait FutureExt {
     /// The type of the future.
     type Future: std::future::Future;
@@ -50,8 +50,8 @@ pub trait FutureExt {
     ///
     /// ## Returns
     ///
-    /// A future that resolves to the return value of the original future on success, or
-    /// [CancelledByShutdown] when a cancellation happened.
+    /// A future that resolves to either the return value of the original future, or to
+    /// [CancelledByShutdown] when a shutdown happened.
     ///
     /// # Arguments
     ///

--- a/src/future_ext.rs
+++ b/src/future_ext.rs
@@ -8,7 +8,7 @@ pin_project! {
     /// A Future that is resolved once the corresponding task is finished
     /// or a shutdown is initiated.
     #[must_use = "futures do nothing unless polled"]
-    pub struct CancelOnShutdownFuture<'a, T>{
+    pub struct CancelOnShutdownFuture<'a, T: std::future::Future>{
         #[pin]
         future: T,
         #[pin]
@@ -16,10 +16,7 @@ pin_project! {
     }
 }
 
-impl<T> std::future::Future for CancelOnShutdownFuture<'_, T>
-where
-    T: std::future::Future,
-{
+impl<T: std::future::Future> std::future::Future for CancelOnShutdownFuture<'_, T> {
     type Output = Result<T::Output, CancelledByShutdown>;
 
     fn poll(
@@ -47,7 +44,7 @@ where
 /// Extends the [std::future::Future] trait with a couple of useful utility functions.
 pub trait FutureExt {
     /// The type of the future.
-    type Future;
+    type Future: std::future::Future;
 
     /// Cancels the future when a shutdown is initiated.
     ///

--- a/src/future_ext.rs
+++ b/src/future_ext.rs
@@ -1,4 +1,4 @@
-use crate::{errors::CancelOnShutdownError, SubsystemHandle};
+use crate::{errors::CancelledByShutdown, SubsystemHandle};
 
 use pin_project_lite::pin_project;
 
@@ -20,7 +20,7 @@ impl<T> std::future::Future for CancelOnShutdownFuture<'_, T>
 where
     T: std::future::Future,
 {
-    type Output = Result<T::Output, CancelOnShutdownError>;
+    type Output = Result<T::Output, CancelledByShutdown>;
 
     fn poll(
         self: std::pin::Pin<&mut Self>,
@@ -32,7 +32,7 @@ where
 
         // Abort if there is a shutdown
         match this.cancellation.as_mut().poll(cx) {
-            Poll::Ready(()) => return Poll::Ready(Err(CancelOnShutdownError::CancelledByShutdown)),
+            Poll::Ready(()) => return Poll::Ready(Err(CancelledByShutdown)),
             Poll::Pending => (),
         }
 

--- a/src/future_ext.rs
+++ b/src/future_ext.rs
@@ -1,0 +1,99 @@
+use std::{marker::PhantomData, pin::Pin};
+
+use crate::{errors::CancelOnShutdownError, SubsystemHandle};
+
+use pin_project_lite::pin_project;
+
+pin_project! {
+    /// aaa
+    #[must_use = "futures do nothing unless polled"]
+    pub struct CancelOnShutdownFuture<'a, T: 'a>{
+        //future: Pin<Box<dyn std::future::Future<Output = Result<T, CancelOnShutdownError>> + Send + Sync >>,
+        #[pin]
+        f: T,
+        x: PhantomData<&'a T>
+    }
+}
+
+// impl<T> std::future::Future for CancelOnShutdownFuture<T> {
+//     type Output = Result<T, CancelOnShutdownError>;
+
+//     fn poll(
+//         self: std::pin::Pin<&mut Self>,
+//         cx: &mut std::task::Context<'_>,
+//     ) -> std::task::Poll<Self::Output> {
+//         let this = self.project();
+//         this.f.poll(cx)
+//     }
+// }
+
+impl<'a, T> std::future::Future for CancelOnShutdownFuture<'a, T>
+where
+    T: std::future::Future + Send + Sync + 'a,
+{
+    type Output = T::Output;
+
+    fn poll(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Self::Output> {
+        let mut this = self.project();
+        this.f.as_mut().poll(cx)
+    }
+}
+
+/// Extends the [std::future::Future] trait with a couple of useful utility functions
+pub trait FutureExt<'a> {
+    /// The return type of the future
+    type Output;
+
+    /// Cancels the future when a shutdown is initiated.
+    ///
+    /// # Arguments
+    ///
+    /// * `subsys` - The [SubsystemHandle] to recieve the shutdown request from.
+    ///
+    /// # Returns
+    ///
+    /// A future that resolves to the return value of the original future on success, or a
+    /// [CancelOnShutdownError] when a cancellation happened.
+    fn cancel_on_shutdown(
+        self,
+        subsys: &SubsystemHandle,
+    ) -> CancelOnShutdownFuture<'a, Self::Output>;
+}
+
+fn create_cancel_on_shutdown_future<'a, T>(
+    f: T,
+    subsys: SubsystemHandle,
+) -> CancelOnShutdownFuture<'a, T>
+where
+    T: std::future::Future + Send + Sync + 'a,
+{
+    // let future = Box::pin(async move {
+    //     let x = f;
+    //     tokio::select! {
+    //         _ = subsys.on_shutdown_requested() => Err(CancelOnShutdownError::CancelledByShutdown),
+    //         res = f => Ok(res)
+    //     }
+    // });
+
+    CancelOnShutdownFuture { f, x: PhantomData }
+}
+
+impl<'a, T> FutureExt<'a> for T
+where
+    T: std::future::Future + Send + Sync + 'a,
+{
+    type Output = T;
+
+    fn cancel_on_shutdown(
+        self,
+        subsys: &SubsystemHandle,
+    ) -> CancelOnShutdownFuture<'a, Self::Output> {
+        let subsys = subsys.clone();
+
+        create_cancel_on_shutdown_future(self, subsys)
+        //todo!()
+    }
+}

--- a/src/future_ext.rs
+++ b/src/future_ext.rs
@@ -31,9 +31,9 @@ pin_project! {
 //     }
 // }
 
-impl<'a, 'b, T> std::future::Future for CancelOnShutdownFuture<'a, 'b, T>
+impl<'b, T> std::future::Future for CancelOnShutdownFuture<'_, 'b, T>
 where
-    T: std::future::Future + Send + Sync + 'a,
+    T: std::future::Future + Send + Sync,
 {
     type Output = Result<T::Output, CancelOnShutdownError>;
 
@@ -60,7 +60,7 @@ where
 }
 
 /// Extends the [std::future::Future] trait with a couple of useful utility functions
-pub trait FutureExt<'a, 'b> {
+pub trait FutureExt {
     /// The return type of the future
     type Output;
 
@@ -76,20 +76,20 @@ pub trait FutureExt<'a, 'b> {
     /// [CancelOnShutdownError] when a cancellation happened.
     fn cancel_on_shutdown(
         self,
-        subsys: &'b SubsystemHandle,
-    ) -> CancelOnShutdownFuture<'a, 'b, Self::Output>;
+        subsys: &SubsystemHandle,
+    ) -> CancelOnShutdownFuture<'_, '_, Self::Output>;
 }
 
-impl<'a, 'b, T> FutureExt<'a, 'b> for T
+impl<T> FutureExt for T
 where
-    T: std::future::Future + Send + Sync + 'a,
+    T: std::future::Future + Send + Sync,
 {
     type Output = T;
 
     fn cancel_on_shutdown(
         self,
-        subsys: &'b SubsystemHandle,
-    ) -> CancelOnShutdownFuture<'a, 'b, Self::Output> {
+        subsys: &SubsystemHandle,
+    ) -> CancelOnShutdownFuture<'_, '_, Self::Output> {
         let cancellation = subsys.local_shutdown_token().wait_for_shutdown();
 
         CancelOnShutdownFuture {

--- a/src/future_ext.rs
+++ b/src/future_ext.rs
@@ -41,7 +41,7 @@ impl<T: std::future::Future> std::future::Future for CancelOnShutdownFuture<'_, 
     }
 }
 
-/// Extends the [std::future::Future] trait with a useful utility functions.
+/// Extends the [std::future::Future] trait with useful utility functions.
 pub trait FutureExt {
     /// The type of the future.
     type Future: std::future::Future;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,6 +105,7 @@ impl<T> ErrTypeTraits for T where
 
 pub mod errors;
 mod exit_state;
+mod future_ext;
 mod into_subsystem;
 mod runner;
 mod shutdown_token;
@@ -115,6 +116,7 @@ mod utils;
 
 use shutdown_token::ShutdownToken;
 
+pub use future_ext::FutureExt;
 pub use into_subsystem::IntoSubsystem;
 pub use subsystem::NestedSubsystem;
 pub use subsystem::SubsystemHandle;

--- a/src/shutdown_token.rs
+++ b/src/shutdown_token.rs
@@ -1,4 +1,4 @@
-use tokio_util::sync::CancellationToken;
+use tokio_util::sync::{CancellationToken, WaitForCancellationFuture};
 
 #[derive(Clone)]
 #[doc(hidden)]
@@ -26,8 +26,8 @@ impl ShutdownToken {
         }
     }
 
-    pub async fn wait_for_shutdown(&self) {
-        self.token.cancelled().await
+    pub fn wait_for_shutdown(&self) -> WaitForCancellationFuture<'_> {
+        self.token.cancelled()
     }
 
     pub fn is_shutting_down(&self) -> bool {

--- a/tests/cancel_on_shutdown.rs
+++ b/tests/cancel_on_shutdown.rs
@@ -1,0 +1,79 @@
+use tokio::time::{sleep, Duration};
+use tokio_graceful_shutdown::{errors::CancelledByShutdown, FutureExt, SubsystemHandle, Toplevel};
+
+pub mod common;
+use common::setup;
+
+use std::error::Error;
+
+/// Wrapper function to simplify lambdas
+type BoxedError = Box<dyn Error + Sync + Send>;
+type BoxedResult = Result<(), BoxedError>;
+
+#[tokio::test]
+async fn cancel_on_shutdown_propagates_result() {
+    setup();
+
+    let subsystem1 = |subsys: SubsystemHandle| async move {
+        let compute_value = async {
+            sleep(Duration::from_millis(10)).await;
+            42
+        };
+
+        let value = compute_value.cancel_on_shutdown(&subsys).await;
+
+        assert_eq!(value.ok(), Some(42));
+
+        BoxedResult::Ok(())
+    };
+
+    let subsystem2 = |subsys: SubsystemHandle| async move {
+        async fn compute_value() -> i32 {
+            sleep(Duration::from_millis(10)).await;
+            42
+        }
+
+        let value = compute_value().cancel_on_shutdown(&subsys).await;
+
+        assert_eq!(value.ok(), Some(42));
+
+        BoxedResult::Ok(())
+    };
+
+    let result = Toplevel::<BoxedError>::new()
+        .start("subsys1", subsystem1)
+        .start("subsys2", subsystem2)
+        .handle_shutdown_requests(Duration::from_millis(200))
+        .await;
+
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn cancel_on_shutdown_cancels_on_shutdown() {
+    setup();
+
+    let subsystem = |subsys: SubsystemHandle| async move {
+        async fn compute_value(subsys: SubsystemHandle) -> i32 {
+            sleep(Duration::from_millis(100)).await;
+            subsys.request_shutdown();
+            sleep(Duration::from_millis(100)).await;
+            42
+        }
+
+        let value = compute_value(subsys.clone())
+            .cancel_on_shutdown(&subsys)
+            .await;
+
+        assert!(matches!(value, Err(CancelledByShutdown)));
+
+        BoxedResult::Ok(())
+    };
+
+    let result = Toplevel::<BoxedError>::new()
+        .start("subsys", subsystem)
+        .handle_shutdown_requests(Duration::from_millis(200))
+        .await;
+
+    assert!(result.is_ok());
+}


### PR DESCRIPTION
Adds the `.cancel_on_shutdown()` method to Futures, to reduce boilerplate for user.

Related to https://github.com/Finomnis/tokio-graceful-shutdown/issues/40.