### PR TITLE
Implement `Clone`, `Copy` for `NestedSubsystem`

### DIFF
--- a/src/subsystem/identifier.rs
+++ b/src/subsystem/identifier.rs
@@ -1,6 +1,6 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-#[derive(PartialEq, Eq, Debug, Clone)]
+#[derive(PartialEq, Eq, Debug, Clone, Copy)]
 pub struct SubsystemIdentifier {
     id: usize,
 }
@@ -22,7 +22,7 @@ mod tests {
     #[test]
     fn equals_with_itself() {
         let identifier1 = SubsystemIdentifier::create();
-        #[allow(clippy::redundant_clone)]
+        #[allow(clippy::clone_on_copy)]
         let identifier2 = identifier1.clone();
         assert_eq!(identifier1, identifier2);
     }

--- a/src/subsystem/mod.rs
+++ b/src/subsystem/mod.rs
@@ -53,6 +53,7 @@ struct SubsystemDescriptor<ErrType: ErrTypeTraits = crate::BoxedError> {
 /// A nested subsystem. Can be used to perform a partial shutdown.
 ///
 /// For more information, see [`SubsystemHandle::start()`] and [`SubsystemHandle::perform_partial_shutdown()`].
+#[derive(PartialEq, Eq, Debug, Clone, Copy)]
 pub struct NestedSubsystem {
     id: SubsystemIdentifier,
 }


### PR DESCRIPTION
Hello! Thanks for this library! I've added implementations of `Clone` and `Copy` for `NestedSubsystem`. This makes it easier to perform a partial shutdown.