### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ bytemuck = { version = "1.14.0", features = ["derive"] }
 [dev-dependencies]
 # Error propagation
 anyhow = "1.0.75"
-eyre = "0.6.8"
+eyre = "0.6.12"
 miette = { version = "7.2.0", features = ["fancy"] }
 
 # Logging


### PR DESCRIPTION
Bumps the dependency to at least 0.6.12 as per the advisory

[Advisory](https://rustsec.org/advisories/RUSTSEC-2024-0021.html)

(even though this crate may not be using the function mentioned in the advisory, it is better to bump it to ensure that there is no chance of other dependencies pulling it)