### PR TITLE
Pass `SubsystemHandle` parameter as `&mut` instead of owned

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -11,6 +11,5 @@ reviews:
   path_filters:
     - "!target/**"
     - "!Cargo.lock"
-    - "!Cargo.toml"
 chat:
   auto_reply: true

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,7 @@
+language: en-US
+reviews:
+  profile: assertive
+  high_level_summary: true
+  auto_review:
+    enabled: true
+    drafts: false

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -4,6 +4,7 @@ reviews:
   high_level_summary: true
   high_level_summary_in_walkthrough: true
   poem: false
+  in_progress_fortune: false
   auto_review:
     enabled: true
     drafts: false

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -2,6 +2,7 @@ language: en-US
 reviews:
   profile: assertive
   high_level_summary: true
+  high_level_summary_in_walkthrough: true
   auto_review:
     enabled: true
     drafts: false

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -3,6 +3,13 @@ reviews:
   profile: assertive
   high_level_summary: true
   high_level_summary_in_walkthrough: true
+  poem: false
   auto_review:
     enabled: true
     drafts: false
+  path_filters:
+    - "!target/**"
+    - "!Cargo.lock"
+    - "!Cargo.toml"
+chat:
+  auto_reply: true

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Specifically, it provides:
 ## Usage Example
 
 ```rust
-async fn subsys1(subsys: SubsystemHandle) -> Result<()>
+async fn subsys1(subsys: &mut SubsystemHandle) -> Result<()>
 {
     log::info!("Subsystem1 started.");
     subsys.on_shutdown_requested().await;
@@ -40,7 +40,7 @@ This subsystem can now be executed like this:
 ```rust
 #[tokio::main]
 async fn main() -> Result<()> {
-    Toplevel::new(async |s| {
+    Toplevel::new(async |s: &mut SubsystemHandle| {
         s.start(SubsystemBuilder::new("Subsys1", subsys1))
     })
     .catch_signals()

--- a/examples/01_normal_shutdown.rs
+++ b/examples/01_normal_shutdown.rs
@@ -11,7 +11,7 @@ use miette::Result;
 use tokio::time::{Duration, sleep};
 use tokio_graceful_shutdown::{SubsystemBuilder, SubsystemHandle, Toplevel};
 
-async fn subsys1(subsys: SubsystemHandle) -> Result<()> {
+async fn subsys1(subsys: &mut SubsystemHandle) -> Result<()> {
     tracing::info!("Subsystem1 started.");
     subsys.on_shutdown_requested().await;
     tracing::info!("Shutting down Subsystem1 ...");
@@ -20,7 +20,7 @@ async fn subsys1(subsys: SubsystemHandle) -> Result<()> {
     Ok(())
 }
 
-async fn subsys2(subsys: SubsystemHandle) -> Result<()> {
+async fn subsys2(subsys: &mut SubsystemHandle) -> Result<()> {
     tracing::info!("Subsystem2 started.");
     subsys.on_shutdown_requested().await;
     tracing::info!("Shutting down Subsystem2 ...");
@@ -37,7 +37,7 @@ async fn main() -> Result<()> {
         .init();
 
     // Setup and execute subsystem tree
-    Toplevel::new(async |s| {
+    Toplevel::new(async |s: &mut SubsystemHandle| {
         s.start(SubsystemBuilder::new("Subsys1", subsys1));
         s.start(SubsystemBuilder::new("Subsys2", subsys2));
     })

--- a/examples/03_shutdown_timeout.rs
+++ b/examples/03_shutdown_timeout.rs
@@ -8,7 +8,7 @@ use miette::Result;
 use tokio::time::{Duration, sleep};
 use tokio_graceful_shutdown::{SubsystemBuilder, SubsystemHandle, Toplevel};
 
-async fn subsys1(subsys: SubsystemHandle) -> Result<()> {
+async fn subsys1(subsys: &mut SubsystemHandle) -> Result<()> {
     tracing::info!("Subsystem1 started.");
     subsys.on_shutdown_requested().await;
     tracing::info!("Shutting down Subsystem1 ...");
@@ -25,7 +25,7 @@ async fn main() -> Result<()> {
         .init();
 
     // Setup and execute subsystem tree
-    Toplevel::new(async |s| {
+    Toplevel::new(async |s: &mut SubsystemHandle| {
         s.start(SubsystemBuilder::new("Subsys1", subsys1));
     })
     .catch_signals()

--- a/examples/04_subsystem_finished.rs
+++ b/examples/04_subsystem_finished.rs
@@ -9,7 +9,7 @@ use miette::Result;
 use tokio::time::{Duration, sleep};
 use tokio_graceful_shutdown::{SubsystemBuilder, SubsystemHandle, Toplevel};
 
-async fn subsys1(_subsys: SubsystemHandle) -> Result<()> {
+async fn subsys1(_subsys: &mut SubsystemHandle) -> Result<()> {
     tracing::info!("Subsystem1 started.");
     sleep(Duration::from_millis(500)).await;
     tracing::info!("Subsystem1 stopped.");
@@ -19,7 +19,7 @@ async fn subsys1(_subsys: SubsystemHandle) -> Result<()> {
     Ok(())
 }
 
-async fn subsys2(subsys: SubsystemHandle) -> Result<()> {
+async fn subsys2(subsys: &mut SubsystemHandle) -> Result<()> {
     subsys.on_shutdown_requested().await;
     Ok(())
 }
@@ -32,7 +32,7 @@ async fn main() -> Result<()> {
         .init();
 
     // Setup and execute subsystem tree
-    Toplevel::new(async |s| {
+    Toplevel::new(async |s: &mut SubsystemHandle| {
         s.start(SubsystemBuilder::new("Subsys1", subsys1));
         s.start(SubsystemBuilder::new("Subsys2", subsys2));
     })

--- a/examples/05_subsystem_finished_with_error.rs
+++ b/examples/05_subsystem_finished_with_error.rs
@@ -10,7 +10,7 @@ use miette::{Result, miette};
 use tokio::time::{Duration, sleep};
 use tokio_graceful_shutdown::{SubsystemBuilder, SubsystemHandle, Toplevel};
 
-async fn subsys1(_subsys: SubsystemHandle) -> Result<()> {
+async fn subsys1(_subsys: &mut SubsystemHandle) -> Result<()> {
     tracing::info!("Subsystem1 started.");
     sleep(Duration::from_millis(500)).await;
     tracing::info!("Subsystem1 stopped.");
@@ -19,7 +19,7 @@ async fn subsys1(_subsys: SubsystemHandle) -> Result<()> {
     Err(miette!("Subsystem1 failed intentionally."))
 }
 
-async fn subsys2(subsys: SubsystemHandle) -> Result<()> {
+async fn subsys2(subsys: &mut SubsystemHandle) -> Result<()> {
     subsys.on_shutdown_requested().await;
     Ok(())
 }
@@ -32,7 +32,7 @@ async fn main() -> Result<()> {
         .init();
 
     // Setup and execute subsystem tree
-    Toplevel::new(async |s| {
+    Toplevel::new(async |s: &mut SubsystemHandle| {
         s.start(SubsystemBuilder::new("Subsys1", subsys1));
         s.start(SubsystemBuilder::new("Subsys2", subsys2));
     })

--- a/examples/06_nested_subsystems.rs
+++ b/examples/06_nested_subsystems.rs
@@ -5,7 +5,7 @@ use miette::Result;
 use tokio::time::{Duration, sleep};
 use tokio_graceful_shutdown::{SubsystemBuilder, SubsystemHandle, Toplevel};
 
-async fn subsys1(subsys: SubsystemHandle) -> Result<()> {
+async fn subsys1(subsys: &mut SubsystemHandle) -> Result<()> {
     subsys.start(SubsystemBuilder::new("Subsys2", subsys2));
     tracing::info!("Subsystem1 started.");
     subsys.on_shutdown_requested().await;
@@ -15,7 +15,7 @@ async fn subsys1(subsys: SubsystemHandle) -> Result<()> {
     Ok(())
 }
 
-async fn subsys2(subsys: SubsystemHandle) -> Result<()> {
+async fn subsys2(subsys: &mut SubsystemHandle) -> Result<()> {
     tracing::info!("Subsystem2 started.");
     subsys.on_shutdown_requested().await;
     tracing::info!("Shutting down Subsystem2 ...");
@@ -32,7 +32,7 @@ async fn main() -> Result<()> {
         .init();
 
     // Setup and execute subsystem tree
-    Toplevel::new(async |s| {
+    Toplevel::new(async |s: &mut SubsystemHandle| {
         s.start(SubsystemBuilder::new("Subsys1", subsys1));
     })
     .catch_signals()

--- a/examples/07_nested_error.rs
+++ b/examples/07_nested_error.rs
@@ -16,7 +16,7 @@ async fn subsys1(subsys: &mut SubsystemHandle) -> Result<()> {
     Ok(())
 }
 
-async fn subsys2(_subsys: &mut SubsystemHandle) -> Result<()> {
+async fn subsys2(_: &mut SubsystemHandle) -> Result<()> {
     tracing::info!("Subsystem2 started.");
     sleep(Duration::from_millis(500)).await;
 

--- a/examples/07_nested_error.rs
+++ b/examples/07_nested_error.rs
@@ -6,7 +6,7 @@ use miette::{Result, miette};
 use tokio::time::{Duration, sleep};
 use tokio_graceful_shutdown::{SubsystemBuilder, SubsystemHandle, Toplevel};
 
-async fn subsys1(subsys: SubsystemHandle) -> Result<()> {
+async fn subsys1(subsys: &mut SubsystemHandle) -> Result<()> {
     subsys.start(SubsystemBuilder::new("Subsys2", subsys2));
     tracing::info!("Subsystem1 started.");
     subsys.on_shutdown_requested().await;
@@ -16,7 +16,7 @@ async fn subsys1(subsys: SubsystemHandle) -> Result<()> {
     Ok(())
 }
 
-async fn subsys2(_subsys: SubsystemHandle) -> Result<()> {
+async fn subsys2(_subsys: &mut SubsystemHandle) -> Result<()> {
     tracing::info!("Subsystem2 started.");
     sleep(Duration::from_millis(500)).await;
 
@@ -31,7 +31,7 @@ async fn main() -> Result<()> {
         .init();
 
     // Setup and execute subsystem tree
-    Toplevel::new(async |s| {
+    Toplevel::new(async |s: &mut SubsystemHandle| {
         s.start(SubsystemBuilder::new("Subsys1", subsys1));
     })
     .catch_signals()

--- a/examples/08_panic_handling.rs
+++ b/examples/08_panic_handling.rs
@@ -8,7 +8,7 @@ use miette::Result;
 use tokio::time::{Duration, sleep};
 use tokio_graceful_shutdown::{SubsystemBuilder, SubsystemHandle, Toplevel};
 
-async fn subsys1(subsys: SubsystemHandle) -> Result<()> {
+async fn subsys1(subsys: &mut SubsystemHandle) -> Result<()> {
     subsys.start(SubsystemBuilder::new("Subsys2", subsys2));
     tracing::info!("Subsystem1 started.");
     subsys.on_shutdown_requested().await;
@@ -18,7 +18,7 @@ async fn subsys1(subsys: SubsystemHandle) -> Result<()> {
     Ok(())
 }
 
-async fn subsys2(_subsys: SubsystemHandle) -> Result<()> {
+async fn subsys2(_subsys: &mut SubsystemHandle) -> Result<()> {
     tracing::info!("Subsystem2 started.");
     sleep(Duration::from_millis(500)).await;
 
@@ -33,7 +33,7 @@ async fn main() -> Result<()> {
         .init();
 
     // Setup and execute subsystem tree
-    Toplevel::new(async |s| {
+    Toplevel::new(async |s: &mut SubsystemHandle| {
         s.start(SubsystemBuilder::new("Subsys1", subsys1));
     })
     .catch_signals()

--- a/examples/11_double_panic.rs
+++ b/examples/11_double_panic.rs
@@ -11,7 +11,7 @@ use miette::Result;
 use tokio::time::{Duration, sleep};
 use tokio_graceful_shutdown::{SubsystemBuilder, SubsystemHandle, Toplevel};
 
-async fn subsys1(subsys: SubsystemHandle) -> Result<()> {
+async fn subsys1(subsys: &mut SubsystemHandle) -> Result<()> {
     subsys.start(SubsystemBuilder::new("Subsys2", subsys2));
     subsys.start(SubsystemBuilder::new("Subsys3", subsys3));
     tracing::info!("Subsystem1 started.");
@@ -21,14 +21,14 @@ async fn subsys1(subsys: SubsystemHandle) -> Result<()> {
     panic!("Subsystem1 panicked!");
 }
 
-async fn subsys2(_subsys: SubsystemHandle) -> Result<()> {
+async fn subsys2(_subsys: &mut SubsystemHandle) -> Result<()> {
     tracing::info!("Subsystem2 started.");
     sleep(Duration::from_millis(500)).await;
 
     panic!("Subsystem2 panicked!")
 }
 
-async fn subsys3(subsys: SubsystemHandle) -> Result<()> {
+async fn subsys3(subsys: &mut SubsystemHandle) -> Result<()> {
     tracing::info!("Subsystem3 started.");
     subsys.on_shutdown_requested().await;
     tracing::info!("Shutting down Subsystem3 ...");
@@ -45,7 +45,7 @@ async fn main() -> Result<()> {
         .init();
 
     // Setup and execute subsystem tree
-    Toplevel::new(async |s| {
+    Toplevel::new(async |s: &mut SubsystemHandle| {
         s.start(SubsystemBuilder::new("Subsys1", subsys1));
     })
     .catch_signals()

--- a/examples/12_subsystem_auto_restart.rs
+++ b/examples/12_subsystem_auto_restart.rs
@@ -8,7 +8,7 @@ use miette::Result;
 use tokio::time::{Duration, sleep};
 use tokio_graceful_shutdown::{ErrorAction, SubsystemBuilder, SubsystemHandle, Toplevel};
 
-async fn subsys1(subsys: SubsystemHandle) -> Result<()> {
+async fn subsys1(subsys: &mut SubsystemHandle) -> Result<()> {
     // This subsystem panics every two seconds.
     // It should get restarted constantly.
 
@@ -24,7 +24,7 @@ async fn subsys1(subsys: SubsystemHandle) -> Result<()> {
     Ok(())
 }
 
-async fn subsys1_keepalive(subsys: SubsystemHandle) -> Result<()> {
+async fn subsys1_keepalive(subsys: &mut SubsystemHandle) -> Result<()> {
     loop {
         let nested_subsys = subsys.start(
             SubsystemBuilder::new("Subsys1", subsys1)
@@ -52,7 +52,7 @@ async fn main() -> Result<()> {
         .init();
 
     // Setup and execute subsystem tree
-    Toplevel::new(async |s| {
+    Toplevel::new(async |s: &mut SubsystemHandle| {
         s.start(SubsystemBuilder::new("Subsys1Keepalive", subsys1_keepalive));
     })
     .catch_signals()

--- a/examples/12_subsystem_auto_restart.rs
+++ b/examples/12_subsystem_auto_restart.rs
@@ -38,6 +38,10 @@ async fn subsys1_keepalive(subsys: &mut SubsystemHandle) -> Result<()> {
             break;
         }
 
+        if subsys.is_shutdown_requested() {
+            break;
+        }
+
         tracing::info!("Restarting subsystem1 ...");
     }
 

--- a/examples/13_partial_shutdown.rs
+++ b/examples/13_partial_shutdown.rs
@@ -23,7 +23,7 @@ async fn subsys2(subsys: &mut SubsystemHandle) -> Result<()> {
 }
 
 async fn subsys1(subsys: &mut SubsystemHandle) -> Result<()> {
-    // This subsystem shuts down the nested subsystem after 5 seconds.
+    // This subsystem shuts down the nested subsystem after a second.
     tracing::info!("Subsys1 started.");
 
     tracing::info!("Starting nested subsystem ...");

--- a/examples/13_partial_shutdown.rs
+++ b/examples/13_partial_shutdown.rs
@@ -7,14 +7,14 @@ use miette::Result;
 use tokio::time::{Duration, sleep};
 use tokio_graceful_shutdown::{ErrorAction, SubsystemBuilder, SubsystemHandle, Toplevel};
 
-async fn subsys3(subsys: SubsystemHandle) -> Result<()> {
+async fn subsys3(subsys: &mut SubsystemHandle) -> Result<()> {
     tracing::info!("Subsys3 started.");
     subsys.on_shutdown_requested().await;
     tracing::info!("Subsys3 stopped.");
     Ok(())
 }
 
-async fn subsys2(subsys: SubsystemHandle) -> Result<()> {
+async fn subsys2(subsys: &mut SubsystemHandle) -> Result<()> {
     tracing::info!("Subsys2 started.");
     subsys.start(SubsystemBuilder::new("Subsys3", subsys3));
     subsys.on_shutdown_requested().await;
@@ -22,7 +22,7 @@ async fn subsys2(subsys: SubsystemHandle) -> Result<()> {
     Ok(())
 }
 
-async fn subsys1(subsys: SubsystemHandle) -> Result<()> {
+async fn subsys1(subsys: &mut SubsystemHandle) -> Result<()> {
     // This subsystem shuts down the nested subsystem after 5 seconds.
     tracing::info!("Subsys1 started.");
 
@@ -58,7 +58,7 @@ async fn main() -> Result<()> {
         .init();
 
     // Setup and execute subsystem tree
-    Toplevel::new(async |s| {
+    Toplevel::new(async |s: &mut SubsystemHandle| {
         s.start(SubsystemBuilder::new("Subsys1", subsys1));
     })
     .catch_signals()

--- a/examples/14_partial_shutdown_error.rs
+++ b/examples/14_partial_shutdown_error.rs
@@ -23,7 +23,7 @@ async fn subsys2(subsys: &mut SubsystemHandle) -> Result<()> {
 }
 
 async fn subsys1(subsys: &mut SubsystemHandle) -> Result<()> {
-    // This subsystem shuts down the nested subsystem after 5 seconds.
+    // This subsystem shuts down the nested subsystem after a seconds.
     tracing::info!("Subsys1 started.");
 
     tracing::info!("Starting nested subsystem ...");

--- a/examples/14_partial_shutdown_error.rs
+++ b/examples/14_partial_shutdown_error.rs
@@ -8,13 +8,13 @@ use miette::Result;
 use tokio::time::{Duration, sleep};
 use tokio_graceful_shutdown::{ErrorAction, SubsystemBuilder, SubsystemHandle, Toplevel};
 
-async fn subsys3(subsys: SubsystemHandle) -> Result<()> {
+async fn subsys3(subsys: &mut SubsystemHandle) -> Result<()> {
     tracing::info!("Subsys3 started.");
     subsys.on_shutdown_requested().await;
     panic!("Subsystem3 threw an error!")
 }
 
-async fn subsys2(subsys: SubsystemHandle) -> Result<()> {
+async fn subsys2(subsys: &mut SubsystemHandle) -> Result<()> {
     tracing::info!("Subsys2 started.");
     subsys.start(SubsystemBuilder::new("Subsys3", subsys3));
     subsys.on_shutdown_requested().await;
@@ -22,7 +22,7 @@ async fn subsys2(subsys: SubsystemHandle) -> Result<()> {
     Ok(())
 }
 
-async fn subsys1(subsys: SubsystemHandle) -> Result<()> {
+async fn subsys1(subsys: &mut SubsystemHandle) -> Result<()> {
     // This subsystem shuts down the nested subsystem after 5 seconds.
     tracing::info!("Subsys1 started.");
 
@@ -60,7 +60,7 @@ async fn main() -> Result<()> {
         .init();
 
     // Setup and execute subsystem tree
-    Toplevel::new(async |s| {
+    Toplevel::new(async |s: &mut SubsystemHandle| {
         s.start(SubsystemBuilder::new("Subsys1", subsys1));
     })
     .catch_signals()

--- a/examples/15_without_miette.rs
+++ b/examples/15_without_miette.rs
@@ -16,7 +16,7 @@ impl fmt::Display for MyError {
 
 impl Error for MyError {}
 
-async fn subsys1(_subsys: SubsystemHandle) -> Result<(), MyError> {
+async fn subsys1(_subsys: &mut SubsystemHandle) -> Result<(), MyError> {
     tracing::info!("Subsystem1 started.");
     sleep(Duration::from_millis(500)).await;
     tracing::info!("Subsystem1 stopped.");
@@ -33,7 +33,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .init();
 
     // Setup and execute subsystem tree
-    Toplevel::new(async |s| {
+    Toplevel::new(async |s: &mut SubsystemHandle| {
         s.start(SubsystemBuilder::new("Subsys1", subsys1));
     })
     .catch_signals()

--- a/examples/16_with_anyhow.rs
+++ b/examples/16_with_anyhow.rs
@@ -4,7 +4,7 @@ use anyhow::{Result, anyhow};
 use tokio::time::{Duration, sleep};
 use tokio_graceful_shutdown::{SubsystemBuilder, SubsystemHandle, Toplevel};
 
-async fn subsys1(_subsys: SubsystemHandle) -> Result<()> {
+async fn subsys1(_subsys: &mut SubsystemHandle) -> Result<()> {
     tracing::info!("Subsystem1 started.");
     sleep(Duration::from_millis(500)).await;
     tracing::info!("Subsystem1 stopped.");
@@ -21,7 +21,7 @@ async fn main() -> Result<()> {
         .init();
 
     // Setup and execute subsystem tree
-    Toplevel::new(async |s| {
+    Toplevel::new(async |s: &mut SubsystemHandle| {
         s.start(SubsystemBuilder::new("Subsys1", subsys1));
     })
     .catch_signals()

--- a/examples/17_with_eyre.rs
+++ b/examples/17_with_eyre.rs
@@ -4,7 +4,7 @@ use eyre::{Result, eyre};
 use tokio::time::{Duration, sleep};
 use tokio_graceful_shutdown::{SubsystemBuilder, SubsystemHandle, Toplevel};
 
-async fn subsys1(_subsys: SubsystemHandle) -> Result<()> {
+async fn subsys1(_subsys: &mut SubsystemHandle) -> Result<()> {
     tracing::info!("Subsystem1 started.");
     sleep(Duration::from_millis(500)).await;
     tracing::info!("Subsystem1 stopped.");
@@ -21,7 +21,7 @@ async fn main() -> Result<()> {
         .init();
 
     // Setup and execute subsystem tree
-    Toplevel::new(async |s| {
+    Toplevel::new(async |s: &mut SubsystemHandle| {
         s.start(SubsystemBuilder::new("Subsys1", subsys1));
     })
     .catch_signals()

--- a/examples/18_error_type_passthrough.rs
+++ b/examples/18_error_type_passthrough.rs
@@ -15,7 +15,7 @@ enum MyError {
     WithoutData,
 }
 
-async fn subsys1(_subsys: SubsystemHandle<MyError>) -> Result<(), MyError> {
+async fn subsys1(_subsys: &mut SubsystemHandle<MyError>) -> Result<(), MyError> {
     tracing::info!("Subsystem1 started.");
     sleep(Duration::from_millis(200)).await;
     tracing::info!("Subsystem1 stopped.");
@@ -23,7 +23,7 @@ async fn subsys1(_subsys: SubsystemHandle<MyError>) -> Result<(), MyError> {
     Err(MyError::WithData(42))
 }
 
-async fn subsys2(_subsys: SubsystemHandle<MyError>) -> Result<(), MyError> {
+async fn subsys2(_subsys: &mut SubsystemHandle<MyError>) -> Result<(), MyError> {
     tracing::info!("Subsystem2 started.");
     sleep(Duration::from_millis(200)).await;
     tracing::info!("Subsystem2 stopped.");
@@ -31,7 +31,7 @@ async fn subsys2(_subsys: SubsystemHandle<MyError>) -> Result<(), MyError> {
     Err(MyError::WithoutData)
 }
 
-async fn subsys3(_subsys: SubsystemHandle<MyError>) -> Result<(), MyError> {
+async fn subsys3(_subsys: &mut SubsystemHandle<MyError>) -> Result<(), MyError> {
     tracing::info!("Subsystem3 started.");
     sleep(Duration::from_millis(200)).await;
     tracing::info!("Subsystem3 stopped.");
@@ -39,7 +39,7 @@ async fn subsys3(_subsys: SubsystemHandle<MyError>) -> Result<(), MyError> {
     panic!("This subsystem panicked.");
 }
 
-async fn subsys4(_subsys: SubsystemHandle<MyError>) -> Result<(), MyError> {
+async fn subsys4(_subsys: &mut SubsystemHandle<MyError>) -> Result<(), MyError> {
     tracing::info!("Subsystem4 started.");
     sleep(Duration::from_millis(1000)).await;
     tracing::info!("Subsystem4 stopped.");
@@ -49,7 +49,7 @@ async fn subsys4(_subsys: SubsystemHandle<MyError>) -> Result<(), MyError> {
     Ok(())
 }
 
-async fn subsys5(_subsys: SubsystemHandle<MyError>) -> Result<(), MyError> {
+async fn subsys5(_subsys: &mut SubsystemHandle<MyError>) -> Result<(), MyError> {
     tracing::info!("Subsystem5 started.");
     sleep(Duration::from_millis(200)).await;
     tracing::info!("Subsystem5 stopped.");
@@ -66,7 +66,7 @@ async fn subsys5(_subsys: SubsystemHandle<MyError>) -> Result<(), MyError> {
 struct Subsys6;
 
 impl IntoSubsystem<MyError, MyError> for Subsys6 {
-    async fn run(self, _subsys: SubsystemHandle<MyError>) -> Result<(), MyError> {
+    async fn run(self, _subsys: &mut SubsystemHandle<MyError>) -> Result<(), MyError> {
         tracing::info!("Subsystem6 started.");
         sleep(Duration::from_millis(200)).await;
         tracing::info!("Subsystem6 stopped.");
@@ -83,7 +83,7 @@ async fn main() -> Result<(), miette::Report> {
         .init();
 
     // Setup and execute subsystem tree
-    let errors = Toplevel::<MyError>::new(async |s| {
+    let errors = Toplevel::<MyError>::new(async |s: &mut SubsystemHandle<MyError>| {
         s.start(SubsystemBuilder::new("Subsys1", subsys1));
         s.start(SubsystemBuilder::new("Subsys2", subsys2));
         s.start(SubsystemBuilder::new("Subsys3", subsys3));

--- a/examples/19_sequential_shutdown.rs
+++ b/examples/19_sequential_shutdown.rs
@@ -92,13 +92,13 @@ async fn root(subsys: &mut SubsystemHandle) -> Result<()> {
     tracing::info!("Root started.");
 
     tracing::info!("Starting nested subsystems ...");
-    let nested1 = subsys.start(SubsystemBuilder::new("Nested1", nested1));
-    let nested1_finished = nested1.finished();
-    let nested2 = subsys.start(SubsystemBuilder::new(
+    let nested1_handle = subsys.start(SubsystemBuilder::new("Nested1", nested1));
+    let nested1_finished = nested1_handle.finished();
+    let nested2_handle = subsys.start(SubsystemBuilder::new(
         "Nested2",
         async |s: &mut SubsystemHandle| nested2(s, nested1_finished).await,
     ));
-    let nested2_finished = nested2.finished();
+    let nested2_finished = nested2_handle.finished();
     subsys.start(SubsystemBuilder::new(
         "Nested3",
         async |s: &mut SubsystemHandle| nested3(s, nested2_finished).await,

--- a/examples/22_subsystem_abort.rs
+++ b/examples/22_subsystem_abort.rs
@@ -4,7 +4,7 @@ use miette::Result;
 use tokio::time::{Duration, sleep};
 use tokio_graceful_shutdown::{SubsystemBuilder, SubsystemHandle, Toplevel};
 
-async fn subsys1(subsys: SubsystemHandle) -> Result<()> {
+async fn subsys1(subsys: &mut SubsystemHandle) -> Result<()> {
     tracing::info!("Subsystem1 started.");
     let nested = subsys.start(SubsystemBuilder::new("Subsys2", subsys2));
     sleep(Duration::from_millis(500)).await;
@@ -15,7 +15,7 @@ async fn subsys1(subsys: SubsystemHandle) -> Result<()> {
     Ok(())
 }
 
-async fn subsys2(subsys: SubsystemHandle) -> Result<()> {
+async fn subsys2(subsys: &mut SubsystemHandle) -> Result<()> {
     tracing::info!("Subsystem2 started.");
     subsys.start(SubsystemBuilder::new("Subsys3", subsys3));
     loop {
@@ -24,7 +24,7 @@ async fn subsys2(subsys: SubsystemHandle) -> Result<()> {
     }
 }
 
-async fn subsys3(_subsys: SubsystemHandle) -> Result<()> {
+async fn subsys3(_subsys: &mut SubsystemHandle) -> Result<()> {
     tracing::info!("Subsystem3 started.");
     loop {
         tracing::info!("Subsystem3 stuck ...");
@@ -40,7 +40,7 @@ async fn main() -> Result<()> {
         .init();
 
     // Setup and execute subsystem tree
-    Toplevel::new(async |s| {
+    Toplevel::new(async |s: &mut SubsystemHandle| {
         s.start(SubsystemBuilder::new("Subsys1", subsys1));
     })
     .catch_signals()

--- a/examples/23_shutdown_from_external.rs
+++ b/examples/23_shutdown_from_external.rs
@@ -10,12 +10,12 @@ use tokio::{
 use tokio_graceful_shutdown::{FutureExt, SubsystemBuilder, SubsystemHandle, Toplevel};
 use tokio_util::sync::CancellationToken;
 
-async fn counter(subsys: SubsystemHandle) -> Result<()> {
+async fn counter(subsys: &mut SubsystemHandle) -> Result<()> {
     let mut i = 1;
     while !subsys.is_shutdown_requested() {
         tracing::info!("Counter: {}", i);
         sleep(Duration::from_millis(1000))
-            .cancel_on_shutdown(&subsys)
+            .cancel_on_shutdown(subsys)
             .await
             .ok();
 
@@ -31,7 +31,7 @@ fn tokio_thread(shutdown_token: CancellationToken) -> Result<()> {
     Runtime::new().unwrap().block_on(async {
         // Setup and execute subsystem tree
         Toplevel::new_with_shutdown_token(
-            async |s| {
+            async |s: &mut SubsystemHandle| {
                 s.start(SubsystemBuilder::new("Counter", counter));
             },
             shutdown_token,

--- a/examples/tokio_console.rs
+++ b/examples/tokio_console.rs
@@ -16,7 +16,7 @@ use tokio_graceful_shutdown::{FutureExt, SubsystemBuilder, SubsystemHandle, Topl
 use tracing::Level;
 use tracing_subscriber::{fmt::writer::MakeWriterExt, prelude::*};
 
-async fn child(subsys: SubsystemHandle) -> Result<()> {
+async fn child(subsys: &mut SubsystemHandle) -> Result<()> {
     sleep(Duration::from_millis(3000))
         .cancel_on_shutdown(&subsys)
         .await
@@ -24,7 +24,7 @@ async fn child(subsys: SubsystemHandle) -> Result<()> {
     Ok(())
 }
 
-async fn parent(subsys: SubsystemHandle) -> Result<()> {
+async fn parent(subsys: &mut SubsystemHandle) -> Result<()> {
     tracing::info!("Parent started.");
 
     let mut iteration = 0;
@@ -56,7 +56,7 @@ async fn main() -> Result<()> {
         .init();
 
     // Setup and execute subsystem tree
-    Toplevel::new(async |s| {
+    Toplevel::new(async |s: &mut SubsystemHandle| {
         s.start(SubsystemBuilder::new("parent", parent));
     })
     .catch_signals()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,6 +105,23 @@ impl<T> ErrTypeTraits for T where
 {
 }
 
+/// An async function that can be used as a subsystem.
+pub trait AsyncSubsysFn<A, O>: FnOnce(A) -> Self::Fut {
+    /// The produced subsystem future
+    type Fut: Future<Output = O> + Send;
+}
+
+// this tricks allows us to generate a "FnOnce"-like bound with only one lifetime parameter
+// so that functions which capture input argument lifetime in it's output
+// (read "async functions") can meet the bound
+impl<A, O, Out, F> AsyncSubsysFn<A, O> for F
+where
+    Out: Future<Output = O> + Send,
+    F: FnOnce(A) -> Out,
+{
+    type Fut = Out;
+}
+
 pub mod errors;
 
 mod error_action;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@
 //!
 //! This example shows a minimal example of how to launch an asynchronous subsystem with the help of this crate.
 //!
-//! It contains a countdown subsystem that will end the program after 10 seconds.
+//! It contains a countdown subsystem that will end the program after 5 seconds.
 //! During the countdown, the program will react to Ctrl-C/SIGINT/SIGTERM and will cancel the countdown task accordingly.
 //!
 //! ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,6 +125,7 @@ where
 {
     type Fut = Out;
 }
+
 pub mod errors;
 
 mod error_action;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,7 +106,7 @@ impl<T> ErrTypeTraits for T where
 }
 
 /// An async function that can be used as a subsystem.
-pub trait AsyncSubsysFn<A, O>: FnOnce(A) -> Self::Fut {
+pub trait AsyncSubsysFn<A, O>: Send + FnOnce(A) -> Self::Fut {
     /// The produced subsystem future
     type Fut: Future<Output = O> + Send;
 }
@@ -117,7 +117,7 @@ pub trait AsyncSubsysFn<A, O>: FnOnce(A) -> Self::Fut {
 impl<A, O, Out, F> AsyncSubsysFn<A, O> for F
 where
     Out: Future<Output = O> + Send,
-    F: FnOnce(A) -> Out,
+    F: Send + FnOnce(A) -> Out,
 {
     type Fut = Out;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,14 +106,18 @@ impl<T> ErrTypeTraits for T where
 }
 
 /// An async function that can be used as a subsystem.
+///
+/// Note: External users should not implement this trait directly.
+/// Prefer passing `async fn` or async closures; this trait exists to
+/// model those in the public API and may evolve.
 pub trait AsyncSubsysFn<A, O>: Send + FnOnce(A) -> Self::Fut {
     /// The produced subsystem future
     type Fut: Future<Output = O> + Send;
 }
 
-// this tricks allows us to generate a "FnOnce"-like bound with only one lifetime parameter
-// so that functions which capture input argument lifetime in it's output
-// (read "async functions") can meet the bound
+// This trick allows us to generate a “FnOnce”-like bound with only one lifetime parameter,
+// so that functions which capture the input argument’s lifetime in their output
+// (i.e., async functions) can meet the bound.
 impl<A, O, Out, F> AsyncSubsysFn<A, O> for F
 where
     Out: Future<Output = O> + Send,
@@ -121,7 +125,6 @@ where
 {
     type Fut = Out;
 }
-
 pub mod errors;
 
 mod error_action;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@
 //!     }
 //! }
 //!
-//! async fn countdown_subsystem(subsys: SubsystemHandle) -> Result<()> {
+//! async fn countdown_subsystem(subsys: &mut SubsystemHandle) -> Result<()> {
 //!     tokio::select! {
 //!         _ = subsys.on_shutdown_requested() => {
 //!             tracing::info!("Countdown cancelled.");
@@ -52,7 +52,7 @@
 //!         .init();
 //!
 //!     // Setup and execute subsystem tree
-//!     Toplevel::new(async |s| {
+//!     Toplevel::new(async |s: &mut SubsystemHandle| {
 //!         s.start(SubsystemBuilder::new("Countdown", countdown_subsystem));
 //!     })
 //!     .catch_signals()

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -92,21 +92,13 @@ where
         };
 
         // Retrieve the handle that was passed into the subsystem.
-        // Originally it was intended to pass the handle as reference, but due
-        // to complications (https://stackoverflow.com/a/70592053/2902833 and
-        // https://github.com/tokio-rs/tokio/issues/3162) it was decided to
-        // pass ownership instead.
+        // Originally it was intended to pass the handle as reference, but
+        // references do not work well with tokio::spawn.
         //
         // It is still important that the handle does not leak out of the subsystem.
-        let subsystem_handle = match redirected_subsystem_handle.try_recv() {
-            Ok(s) => s,
-            Err(_) => {
-                tracing::error!(
-                    "The SubsystemHandle object must not be leaked out of the subsystem!"
-                );
-                panic!("The SubsystemHandle object must not be leaked out of the subsystem!");
-            }
-        };
+        let subsystem_handle = redirected_subsystem_handle.try_recv().expect(
+            "Internal error, please report at https://github.com/Finomnis/tokio-graceful-shutdown/issues!"
+        );
 
         // Raise potential errors
         let joiner_token = subsystem_handle.joiner_token;

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -9,7 +9,7 @@
 use std::{future::Future, sync::Arc};
 
 use crate::{
-    ErrTypeTraits, SubsystemHandle,
+    AsyncSubsysFn, ErrTypeTraits, SubsystemHandle,
     errors::{SubsystemError, SubsystemFailure},
 };
 
@@ -22,15 +22,14 @@ pub(crate) struct SubsystemRunner {
 
 impl SubsystemRunner {
     #[track_caller]
-    pub(crate) fn new<Fut, Subsys, ErrType: ErrTypeTraits, Err>(
+    pub(crate) fn new<Subsys, ErrType: ErrTypeTraits, Err>(
         name: Arc<str>,
         subsystem: Subsys,
         subsystem_handle: SubsystemHandle<ErrType>,
         guard: AliveGuard,
     ) -> Self
     where
-        Subsys: 'static + FnOnce(SubsystemHandle<ErrType>) -> Fut + Send,
-        Fut: 'static + Future<Output = Result<(), Err>> + Send,
+        Subsys: 'static + for<'a> AsyncSubsysFn<&'a mut SubsystemHandle<ErrType>, Result<(), Err>>,
         Err: Into<ErrType>,
     {
         let future = run_subsystem(name, subsystem, subsystem_handle, guard);
@@ -50,20 +49,19 @@ impl Drop for SubsystemRunner {
 }
 
 #[track_caller]
-fn run_subsystem<Fut, Subsys, ErrType: ErrTypeTraits, Err>(
+fn run_subsystem<Subsys, ErrType: ErrTypeTraits, Err>(
     name: Arc<str>,
     subsystem: Subsys,
     mut subsystem_handle: SubsystemHandle<ErrType>,
     guard: AliveGuard,
 ) -> impl Future<Output = ()> + 'static
 where
-    Subsys: 'static + FnOnce(SubsystemHandle<ErrType>) -> Fut + Send,
-    Fut: 'static + Future<Output = Result<(), Err>> + Send,
+    Subsys: 'static + for<'a> AsyncSubsysFn<&'a mut SubsystemHandle<ErrType>, Result<(), Err>>,
     Err: Into<ErrType>,
 {
     let mut redirected_subsystem_handle = subsystem_handle.delayed_clone();
 
-    let future = async { subsystem(subsystem_handle).await.map_err(|e| e.into()) };
+    let future = async move { subsystem(&mut subsystem_handle).await.map_err(|e| e.into()) };
     let join_handle = crate::tokio_task::spawn(future, &name);
 
     // Abort on drop

--- a/src/subsystem/nested_subsystem.rs
+++ b/src/subsystem/nested_subsystem.rs
@@ -21,13 +21,13 @@ impl<ErrType: ErrTypeTraits> NestedSubsystem<ErrType> {
     /// use tokio::time::{sleep, Duration};
     /// use tokio_graceful_shutdown::{ErrorAction, SubsystemBuilder, SubsystemHandle};
     ///
-    /// async fn nested_subsystem(subsys: SubsystemHandle) -> Result<()> {
+    /// async fn nested_subsystem(subsys: &mut SubsystemHandle) -> Result<()> {
     ///     // This subsystem does nothing but wait for the shutdown to happen
     ///     subsys.on_shutdown_requested().await;
     ///     Ok(())
     /// }
     ///
-    /// async fn subsystem(subsys: SubsystemHandle) -> Result<()> {
+    /// async fn subsystem(subsys: &mut SubsystemHandle) -> Result<()> {
     ///     // This subsystem waits for one second and then performs a partial shutdown
     ///
     ///     // Spawn nested subsystem.

--- a/src/subsystem/subsystem_builder.rs
+++ b/src/subsystem/subsystem_builder.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 use crate::ErrorAction;
 
 /// Configures a subsystem before it gets spawned through
-/// [`SubsystemHandle::start`].
+/// [`SubsystemHandle::start`](crate::SubsystemHandle::start).
 pub struct SubsystemBuilder<'a, Subsys> {
     pub(crate) name: Cow<'a, str>,
     pub(crate) subsystem: Subsys,

--- a/src/subsystem/subsystem_builder.rs
+++ b/src/subsystem/subsystem_builder.rs
@@ -1,30 +1,18 @@
-use std::{borrow::Cow, marker::PhantomData};
+use std::borrow::Cow;
 
-use crate::{AsyncSubsysFn, ErrTypeTraits, ErrorAction, SubsystemHandle};
+use crate::ErrorAction;
 
 /// Configures a subsystem before it gets spawned through
 /// [`SubsystemHandle::start`].
-pub struct SubsystemBuilder<'a, ErrType, Err, Subsys>
-where
-    ErrType: ErrTypeTraits,
-    Subsys: 'static + for<'b> AsyncSubsysFn<&'b mut SubsystemHandle<ErrType>, Result<(), Err>>,
-    Err: Into<ErrType>,
-{
+pub struct SubsystemBuilder<'a, Subsys> {
     pub(crate) name: Cow<'a, str>,
     pub(crate) subsystem: Subsys,
     pub(crate) failure_action: ErrorAction,
     pub(crate) panic_action: ErrorAction,
     pub(crate) detached: bool,
-    #[allow(clippy::type_complexity)]
-    _phantom: PhantomData<fn() -> (ErrType, Err)>,
 }
 
-impl<'a, ErrType, Err, Subsys> SubsystemBuilder<'a, ErrType, Err, Subsys>
-where
-    ErrType: ErrTypeTraits,
-    Subsys: 'static + for<'b> AsyncSubsysFn<&'b mut SubsystemHandle<ErrType>, Result<(), Err>>,
-    Err: Into<ErrType>,
-{
+impl<'a, Subsys> SubsystemBuilder<'a, Subsys> {
     /// Creates a new SubsystemBuilder from a given subsystem
     /// function.
     ///
@@ -40,7 +28,6 @@ where
             failure_action: ErrorAction::Forward,
             panic_action: ErrorAction::Forward,
             detached: false,
-            _phantom: Default::default(),
         }
     }
 

--- a/src/subsystem/subsystem_builder.rs
+++ b/src/subsystem/subsystem_builder.rs
@@ -4,6 +4,7 @@ use crate::ErrorAction;
 
 /// Configures a subsystem before it gets spawned through
 /// [`SubsystemHandle::start`](crate::SubsystemHandle::start).
+#[must_use]
 pub struct SubsystemBuilder<'a, Subsys> {
     pub(crate) name: Cow<'a, str>,
     pub(crate) subsystem: Subsys,

--- a/src/subsystem/subsystem_handle.rs
+++ b/src/subsystem/subsystem_handle.rs
@@ -72,10 +72,7 @@ impl<ErrType: ErrTypeTraits> SubsystemHandle<ErrType> {
     /// }
     /// ```
     #[track_caller]
-    pub fn start<Err, Subsys>(
-        &self,
-        builder: SubsystemBuilder<ErrType, Err, Subsys>,
-    ) -> NestedSubsystem<ErrType>
+    pub fn start<Err, Subsys>(&self, builder: SubsystemBuilder<Subsys>) -> NestedSubsystem<ErrType>
     where
         Subsys: 'static + for<'a> AsyncSubsysFn<&'a mut SubsystemHandle<ErrType>, Result<(), Err>>,
         Err: Into<ErrType>,

--- a/src/subsystem/subsystem_handle.rs
+++ b/src/subsystem/subsystem_handle.rs
@@ -58,12 +58,12 @@ impl<ErrType: ErrTypeTraits> SubsystemHandle<ErrType> {
     /// use miette::Result;
     /// use tokio_graceful_shutdown::{SubsystemBuilder, SubsystemHandle};
     ///
-    /// async fn nested_subsystem(subsys: SubsystemHandle) -> Result<()> {
+    /// async fn nested_subsystem(subsys: &mut SubsystemHandle) -> Result<()> {
     ///     subsys.on_shutdown_requested().await;
     ///     Ok(())
     /// }
     ///
-    /// async fn my_subsystem(subsys: SubsystemHandle) -> Result<()> {
+    /// async fn my_subsystem(subsys: &mut SubsystemHandle) -> Result<()> {
     ///     // start a nested subsystem
     ///     subsys.start(SubsystemBuilder::new("Nested", nested_subsystem));
     ///

--- a/src/subsystem/subsystem_handle/tests.rs
+++ b/src/subsystem/subsystem_handle/tests.rs
@@ -40,12 +40,12 @@ async fn recursive_cancellation_2() {
 
     let (drop_sender, mut drop_receiver) = tokio::sync::mpsc::channel::<()>(1);
 
-    let subsys2 = async move |_| {
+    let subsys2 = async move |_: &mut SubsystemHandle| {
         drop_sender.send(()).await.unwrap();
         std::future::pending::<Result<(), BoxedError>>().await
     };
 
-    let subsys = async |x: SubsystemHandle| {
+    let subsys = async |x: &mut SubsystemHandle| {
         x.start(SubsystemBuilder::new("", subsys2));
 
         Result::<(), BoxedError>::Ok(())

--- a/src/subsystem/subsystem_handle/tests.rs
+++ b/src/subsystem/subsystem_handle/tests.rs
@@ -10,10 +10,13 @@ async fn recursive_cancellation() {
 
     let (drop_sender, mut drop_receiver) = tokio::sync::mpsc::channel::<()>(1);
 
-    root_handle.start(SubsystemBuilder::new("", async move |_| {
-        drop_sender.send(()).await.unwrap();
-        std::future::pending::<Result<(), BoxedError>>().await
-    }));
+    root_handle.start(SubsystemBuilder::new(
+        "",
+        async move |_: &mut SubsystemHandle<BoxedError>| {
+            drop_sender.send(()).await.unwrap();
+            std::future::pending::<Result<(), BoxedError>>().await
+        },
+    ));
 
     // Make sure we are executing the subsystem
     let recv_result = timeout(Duration::from_millis(100), drop_receiver.recv())

--- a/src/toplevel.rs
+++ b/src/toplevel.rs
@@ -23,14 +23,14 @@ use crate::{
 /// use tokio::time::Duration;
 /// use tokio_graceful_shutdown::{SubsystemBuilder, SubsystemHandle, Toplevel};
 ///
-/// async fn my_subsystem(subsys: SubsystemHandle) -> Result<()> {
+/// async fn my_subsystem(subsys: &mut SubsystemHandle) -> Result<()> {
 ///     subsys.request_shutdown();
 ///     Ok(())
 /// }
 ///
 /// #[tokio::main]
 /// async fn main() -> Result<()> {
-///     Toplevel::new(async |s| {
+///     Toplevel::new(async |s: &mut SubsystemHandle| {
 ///         s.start(SubsystemBuilder::new("MySubsystem", my_subsystem));
 ///     })
 ///     .catch_signals()

--- a/src/toplevel.rs
+++ b/src/toplevel.rs
@@ -59,7 +59,7 @@ impl<ErrType: ErrTypeTraits> Toplevel<ErrType> {
     #[track_caller]
     pub fn new<Subsys>(subsystem: Subsys) -> Self
     where
-        Subsys: 'static + Send + for<'a> AsyncSubsysFn<&'a mut SubsystemHandle<ErrType>, ()>,
+        Subsys: 'static + for<'a> AsyncSubsysFn<&'a mut SubsystemHandle<ErrType>, ()>,
     {
         Self::new_with_shutdown_token(subsystem, CancellationToken::new())
     }
@@ -82,7 +82,7 @@ impl<ErrType: ErrTypeTraits> Toplevel<ErrType> {
         shutdown_token: CancellationToken,
     ) -> Self
     where
-        Subsys: 'static + for<'a> AsyncSubsysFn<&'a mut SubsystemHandle<ErrType>, ()> + Send,
+        Subsys: 'static + for<'a> AsyncSubsysFn<&'a mut SubsystemHandle<ErrType>, ()>,
     {
         let (error_sender, errors) = mpsc::unbounded_channel();
 
@@ -101,8 +101,8 @@ impl<ErrType: ErrTypeTraits> Toplevel<ErrType> {
 
         let toplevel_subsys = root_handle.start_with_abs_name(
             Arc::from("/"),
-            async |mut s| {
-                subsystem(&mut s).await;
+            async move |s: &mut SubsystemHandle<ErrType>| {
+                subsystem(s).await;
                 Result::<(), ErrType>::Ok(())
             },
             ErrorActions {

--- a/tests/integration_test_2.rs
+++ b/tests/integration_test_2.rs
@@ -4,43 +4,10 @@ use tracing_test::traced_test;
 
 pub mod common;
 
-use std::sync::{
-    Arc, Mutex,
-    atomic::{AtomicBool, Ordering},
-};
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use crate::common::Event;
 use common::BoxedResult;
-
-#[tokio::test(start_paused = true)]
-#[traced_test]
-async fn leak_subsystem_handle() {
-    let subsys_ext: Arc<Mutex<Option<SubsystemHandle>>> = Default::default();
-    let subsys_ext2 = Arc::clone(&subsys_ext);
-
-    let subsystem = async move |subsys: SubsystemHandle| {
-        subsys.on_shutdown_requested().await;
-
-        *subsys_ext2.lock().unwrap() = Some(subsys);
-
-        BoxedResult::Ok(())
-    };
-
-    let toplevel = Toplevel::new(async move |s| {
-        s.start(SubsystemBuilder::new("subsys", subsystem));
-
-        sleep(Duration::from_millis(100)).await;
-        s.request_shutdown();
-    });
-
-    let result = toplevel
-        .handle_shutdown_requests(Duration::from_millis(100))
-        .await;
-    assert!(result.is_err());
-    assert!(logs_contain(
-        "The SubsystemHandle object must not be leaked out of the subsystem!"
-    ));
-}
 
 #[tokio::test(start_paused = true)]
 #[traced_test]
@@ -50,7 +17,7 @@ async fn wait_for_children() {
     let (nested2_started, set_nested2_started) = Event::create();
     let (nested2_finished, set_nested2_finished) = Event::create();
 
-    let nested_subsys2 = async move |subsys: SubsystemHandle| {
+    let nested_subsys2 = async move |subsys: &mut SubsystemHandle| {
         set_nested2_started();
         subsys.on_shutdown_requested().await;
         sleep(Duration::from_millis(100)).await;
@@ -58,7 +25,7 @@ async fn wait_for_children() {
         BoxedResult::Ok(())
     };
 
-    let nested_subsys1 = async move |subsys: SubsystemHandle| {
+    let nested_subsys1 = async move |subsys: &mut SubsystemHandle| {
         subsys.start(SubsystemBuilder::new("nested2", nested_subsys2));
         set_nested1_started();
         subsys.on_shutdown_requested().await;
@@ -67,7 +34,7 @@ async fn wait_for_children() {
         BoxedResult::Ok(())
     };
 
-    let subsys1 = async move |subsys: SubsystemHandle| {
+    let subsys1 = async move |subsys: &mut SubsystemHandle| {
         subsys.start(SubsystemBuilder::new("nested1", nested_subsys1));
 
         sleep(Duration::from_millis(100)).await;
@@ -87,7 +54,7 @@ async fn wait_for_children() {
         BoxedResult::Ok(())
     };
 
-    Toplevel::new(async |s| {
+    Toplevel::new(async |s: &mut SubsystemHandle| {
         s.start(SubsystemBuilder::new("subsys", subsys1));
     })
     .handle_shutdown_requests(Duration::from_millis(500))
@@ -104,14 +71,14 @@ async fn request_local_shutdown() {
     let (nested2_finished, set_nested2_finished) = Event::create();
     let (global_finished, set_global_finished) = Event::create();
 
-    let nested_subsys2 = async move |subsys: SubsystemHandle| {
+    let nested_subsys2 = async move |subsys: &mut SubsystemHandle| {
         set_nested2_started();
         subsys.on_shutdown_requested().await;
         set_nested2_finished();
         BoxedResult::Ok(())
     };
 
-    let nested_subsys1 = async move |subsys: SubsystemHandle| {
+    let nested_subsys1 = async move |subsys: &mut SubsystemHandle| {
         subsys.start(SubsystemBuilder::new("nested2", nested_subsys2));
         set_nested1_started();
         subsys.on_shutdown_requested().await;
@@ -119,7 +86,7 @@ async fn request_local_shutdown() {
         BoxedResult::Ok(())
     };
 
-    let subsys1 = async move |subsys: SubsystemHandle| {
+    let subsys1 = async move |subsys: &mut SubsystemHandle| {
         subsys.start(SubsystemBuilder::new("nested1", nested_subsys1));
 
         sleep(Duration::from_millis(100)).await;
@@ -148,7 +115,7 @@ async fn request_local_shutdown() {
         BoxedResult::Ok(())
     };
 
-    Toplevel::new(async move |s| {
+    Toplevel::new(async move |s: &mut SubsystemHandle| {
         s.start(SubsystemBuilder::new("subsys", subsys1));
 
         s.on_shutdown_requested().await;
@@ -167,7 +134,7 @@ async fn shutdown_through_signal_2() {
     use nix::unistd::Pid;
     use tokio_graceful_shutdown::FutureExt;
 
-    let subsystem = async |subsys: SubsystemHandle| {
+    let subsystem = async |subsys: &mut SubsystemHandle| {
         subsys.on_shutdown_requested().await;
         sleep(Duration::from_millis(200)).await;
         BoxedResult::Ok(())
@@ -181,11 +148,11 @@ async fn shutdown_through_signal_2() {
             signal::kill(Pid::this(), Signal::SIGTERM).unwrap();
         },
         async {
-            let result = Toplevel::new(async move |s| {
+            let result = Toplevel::new(async move |s: &mut SubsystemHandle| {
                 s.start(SubsystemBuilder::new("subsys", subsystem));
                 assert!(
                     sleep(Duration::from_millis(1000))
-                        .cancel_on_shutdown(&s)
+                        .cancel_on_shutdown(s)
                         .await
                         .is_err()
                 );
@@ -202,7 +169,7 @@ async fn shutdown_through_signal_2() {
 #[tokio::test(start_paused = true)]
 #[traced_test]
 async fn cancellation_token() {
-    let subsystem = async |subsys: SubsystemHandle| {
+    let subsystem = async |subsys: &mut SubsystemHandle| {
         let cancellation_token = subsys.create_cancellation_token();
 
         assert!(!cancellation_token.is_cancelled());
@@ -212,7 +179,7 @@ async fn cancellation_token() {
         BoxedResult::Ok(())
     };
 
-    let toplevel = Toplevel::new(async move |s| {
+    let toplevel = Toplevel::new(async move |s: &mut SubsystemHandle| {
         s.start(SubsystemBuilder::new("subsys", subsystem));
 
         sleep(Duration::from_millis(100)).await;
@@ -228,7 +195,7 @@ async fn cancellation_token() {
 #[tokio::test(start_paused = true)]
 #[traced_test]
 async fn cancellation_token_does_not_propagate_up() {
-    let subsystem = async |subsys: SubsystemHandle| {
+    let subsystem = async |subsys: &mut SubsystemHandle| {
         let cancellation_token = subsys.create_cancellation_token();
 
         cancellation_token.cancel();
@@ -237,7 +204,7 @@ async fn cancellation_token_does_not_propagate_up() {
         BoxedResult::Ok(())
     };
 
-    let toplevel = Toplevel::new(async move |s| {
+    let toplevel = Toplevel::new(async move |s: &mut SubsystemHandle| {
         s.start(SubsystemBuilder::new("subsys", subsystem));
     });
 
@@ -250,12 +217,12 @@ async fn cancellation_token_does_not_propagate_up() {
 #[tokio::test(start_paused = true)]
 #[traced_test]
 async fn subsystem_finished_works_correctly() {
-    let subsystem = async |subsys: SubsystemHandle| {
+    let subsystem = async |subsys: &mut SubsystemHandle| {
         subsys.on_shutdown_requested().await;
         BoxedResult::Ok(())
     };
 
-    let toplevel = Toplevel::new(async move |s| {
+    let toplevel = Toplevel::new(async move |s: &mut SubsystemHandle| {
         let nested = s.start(SubsystemBuilder::new("subsys", subsystem));
         let nested_finished = nested.finished();
 
@@ -287,14 +254,14 @@ async fn shutdown_does_not_propagate_to_detached_subsystem() {
     let (nested_started, set_nested_started) = Event::create();
     let (nested_finished, set_nested_finished) = Event::create();
 
-    let detached_subsystem = async |subsys: SubsystemHandle| {
+    let detached_subsystem = async |subsys: &mut SubsystemHandle| {
         set_nested_started();
         subsys.on_shutdown_requested().await;
         set_nested_finished();
         BoxedResult::Ok(())
     };
 
-    let subsystem = async move |subsys: SubsystemHandle| {
+    let subsystem = async move |subsys: &mut SubsystemHandle| {
         let nested = subsys.start(SubsystemBuilder::new("detached", detached_subsystem).detached());
         sleep(Duration::from_millis(20)).await;
         assert!(nested_started.get());
@@ -313,7 +280,7 @@ async fn shutdown_does_not_propagate_to_detached_subsystem() {
         BoxedResult::Ok(())
     };
 
-    let toplevel = Toplevel::new(async move |s| {
+    let toplevel = Toplevel::new(async move |s: &mut SubsystemHandle| {
         s.start(SubsystemBuilder::new("subsys", subsystem));
 
         sleep(Duration::from_millis(100)).await;


### PR DESCRIPTION
That was the intention all along, but it was very hard to do, because async closures and reference arguments really hate each other.

This change makes it impossible to leak the `SubsystemHandle` object out of the subsystem function. Before, it was a runtime panic, now it's a compiler error.