### PR TITLE
docs: Fixed missing semicolon in Usage Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This subsystem can now be executed like this:
 #[tokio::main]
 async fn main() -> Result<()> {
     Toplevel::new(async |s: &mut SubsystemHandle| {
-        s.start(SubsystemBuilder::new("Subsys1", subsys1))
+        s.start(SubsystemBuilder::new("Subsys1", subsys1));
     })
     .catch_signals()
     .handle_shutdown_requests(Duration::from_millis(1000))


### PR DESCRIPTION
While attempting to copy the Usage Example from the crates.io website I noticed that the semicolon was missing on this line.
