### PR TITLE
Support alternative error types in FutureExt::cancel_on_shutdown

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tokio-graceful-shutdown"
 authors = ["Finomnis <finomnis@gmail.com>"]
-version = "0.19.3"
+version = "0.20.0"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT OR Apache-2.0"

--- a/src/future_ext.rs
+++ b/src/future_ext.rs
@@ -1,4 +1,4 @@
-use crate::{SubsystemHandle, errors::CancelledByShutdown};
+use crate::{ErrTypeTraits, SubsystemHandle, errors::CancelledByShutdown};
 
 use pin_project_lite::pin_project;
 
@@ -79,16 +79,19 @@ pub trait FutureExt {
     ///     Ok(())
     /// }
     /// ```
-    fn cancel_on_shutdown(
+    fn cancel_on_shutdown<ErrType: ErrTypeTraits>(
         self,
-        subsys: &SubsystemHandle,
+        subsys: &SubsystemHandle<ErrType>,
     ) -> CancelOnShutdownFuture<'_, Self::Future>;
 }
 
 impl<T: std::future::Future> FutureExt for T {
     type Future = T;
 
-    fn cancel_on_shutdown(self, subsys: &SubsystemHandle) -> CancelOnShutdownFuture<'_, T> {
+    fn cancel_on_shutdown<ErrType: ErrTypeTraits>(
+        self,
+        subsys: &SubsystemHandle<ErrType>,
+    ) -> CancelOnShutdownFuture<'_, T> {
         let cancellation = subsys.get_cancellation_token().cancelled();
 
         CancelOnShutdownFuture {

--- a/tests/cancel_on_shutdown.rs
+++ b/tests/cancel_on_shutdown.rs
@@ -91,7 +91,7 @@ async fn cancel_on_shutdown_supports_alternative_error_types() {
                 .await;
 
             assert!(matches!(result, Err(CancelledByShutdown)));
-            result.into()
+            result.map_err(ErrType::from)
         };
 
         let result = Toplevel::<ErrType>::new(async move |s: &mut SubsystemHandle<ErrType>| {

--- a/tests/cancel_on_shutdown.rs
+++ b/tests/cancel_on_shutdown.rs
@@ -1,7 +1,8 @@
 mod common;
 use tokio::time::{Duration, sleep};
 use tokio_graceful_shutdown::{
-    FutureExt, SubsystemBuilder, SubsystemHandle, Toplevel, errors::CancelledByShutdown,
+    ErrTypeTraits, FutureExt, SubsystemBuilder, SubsystemHandle, Toplevel,
+    errors::{CancelledByShutdown, SubsystemError},
 };
 use tracing_test::traced_test;
 
@@ -71,4 +72,49 @@ async fn cancel_on_shutdown_cancels_on_shutdown() {
     .await;
 
     assert!(result.is_ok());
+}
+
+#[tokio::test(start_paused = true)]
+#[traced_test]
+async fn cancel_on_shutdown_supports_alternative_error_types() {
+    #[derive(Debug, thiserror::Error)]
+    enum MyError {
+        #[error("MyError.Cancelled: {0}")]
+        Cancelled(#[from] CancelledByShutdown),
+    }
+
+    async fn inner<ErrType: ErrTypeTraits + From<CancelledByShutdown>>() -> Result<(), ErrType> {
+        let subsystem = async |subsys: &mut SubsystemHandle<ErrType>| {
+            subsys.request_shutdown();
+            let result = sleep(Duration::from_millis(100))
+                .cancel_on_shutdown(subsys)
+                .await;
+
+            assert!(matches!(result, Err(CancelledByShutdown)));
+            result.into()
+        };
+
+        let result = Toplevel::<ErrType>::new(async move |s: &mut SubsystemHandle<ErrType>| {
+            s.start(SubsystemBuilder::new(
+                std::any::type_name::<ErrType>(),
+                subsystem,
+            ));
+        })
+        .handle_shutdown_requests(Duration::from_millis(200))
+        .await;
+
+        let errors = result.unwrap_err();
+        let _error: &ErrType = match &errors.get_subsystem_errors()[0] {
+            SubsystemError::Failed(_, subsystem_failure) => subsystem_failure.get_error(),
+            SubsystemError::Panicked(_) => panic!(),
+        };
+
+        Ok(())
+    }
+
+    inner::<BoxedError>().await.unwrap();
+    inner::<MyError>().await.unwrap();
+    inner::<anyhow::Error>().await.unwrap();
+    inner::<eyre::Error>().await.unwrap();
+    inner::<miette::Error>().await.unwrap();
 }


### PR DESCRIPTION
Just some QOL I found myself wanting, figured I should contribute upstream.